### PR TITLE
docs: restore BRIDGE name and sanitize infrastructure references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <h1>BRIDGE</h1>
 
-<p><strong>Scientific agent for cell-therapy product evaluation</strong></p>
 <p><em>Brain-Referenced In vivo-to-in vitro Developmental Guidance and Evaluation</em></p>
+<p><strong>Scientific agent for cell-therapy product evaluation</strong></p>
 
 <p>
   <a href="https://github.com/starvingarc/BRIDGE/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/starvingarc/BRIDGE/actions/workflows/ci.yml/badge.svg"></a>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 <h1>BRIDGE</h1>
 
-<p><strong>Scientific agent for cell-therapy product evaluation</strong></p>
+<p>
+  <strong>Brain-Referenced In vivo-to-in vitro Developmental Guidance and Evaluation</strong><br>
+  Scientific agent for cell-therapy product evaluation
+</p>
 
 <p>
   <a href="https://github.com/starvingarc/BRIDGE/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/starvingarc/BRIDGE/actions/workflows/ci.yml/badge.svg"></a>

--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 <h1>BRIDGE</h1>
 
-<p>
-  <strong>Brain-Referenced In vivo-to-in vitro Developmental Guidance and Evaluation</strong><br>
-  Scientific agent for cell-therapy product evaluation
-</p>
+<p><strong>Scientific agent for cell-therapy product evaluation</strong></p>
+<p><em>Brain-Referenced In vivo-to-in vitro Developmental Guidance and Evaluation</em></p>
 
 <p>
   <a href="https://github.com/starvingarc/BRIDGE/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/starvingarc/BRIDGE/actions/workflows/ci.yml/badge.svg"></a>

--- a/docs/BRIDGE_PRD.md
+++ b/docs/BRIDGE_PRD.md
@@ -3,6 +3,7 @@
 | 项目 | 内容 |
 | --- | --- |
 | 项目全称 | Brain-Referenced In vivo-to-in vitro Developmental Guidance and Evaluation |
+| 产品形态 | 科学评估智能体（Scientific Agent） |
 | 文档版本 | `v0.1` |
 | 修订日期 | 2026-08-26 |
 | 状态 | `current_primary_specification` |

--- a/docs/BRIDGE_PRD.md
+++ b/docs/BRIDGE_PRD.md
@@ -2,8 +2,9 @@
 
 | 项目 | 内容 |
 | --- | --- |
+| 项目全称 | Brain-Referenced In vivo-to-in vitro Developmental Guidance and Evaluation |
 | 文档版本 | `v0.1` |
-| 修订日期 | 2026-08-10 |
+| 修订日期 | 2026-08-26 |
 | 状态 | `current_primary_specification` |
 | 适用范围 | 研究用途的细胞治疗产品转录组评估；PD hPSC-mDA 为首个实例 |
 | 文档权威性 | 本文档是 BRIDGE 当前唯一主规范；Registry 和 Task Card 是受其约束的实施附件 |

--- a/docs/validation/p0_07_product_comparison_stability_v0.2.md
+++ b/docs/validation/p0_07_product_comparison_stability_v0.2.md
@@ -17,7 +17,7 @@ It does not rerun scientific domains or infer biological desirability.
 
 ## Server verification
 
-The exact staged source was validated on `bridge-amax` under `/data1` only:
+The exact staged source was validated in an isolated private server worktree:
 
 - focused P0-07 suite: **15 passed**;
 - complete repository suite: **1,077 passed**, with eight pre-existing

--- a/docs/validation/p0_10_claim_verifier_20260814.md
+++ b/docs/validation/p0_10_claim_verifier_20260814.md
@@ -366,9 +366,9 @@ The resulting implementation commit was
 were the fully synthetic scRNA upload demo and its documentation; no P0-10,
 P0-08 or P0-09 interface changed.
 
-Validation ran exclusively under `/data1` from a complete transferred Git
-bundle. The old server worktree was not reused because its Git metadata still
-depended on the unavailable legacy volume. A new independent checkout and a
+Validation ran exclusively in an isolated server worktree from a complete
+transferred Git bundle. The old server worktree was not reused because its Git
+metadata still depended on the unavailable legacy volume. A new independent checkout and a
 new append-only evidence directory were used instead. No long-lived Conda
 environment was modified: the existing core environment supplied QC/test
 dependencies, while the exact pinned `regex` 2026.7.19 package was copied from

--- a/docs/validation/repository_readability_20260825.md
+++ b/docs/validation/repository_readability_20260825.md
@@ -11,8 +11,8 @@ adapter, scientific status, score or release authority.
 
 ## Server environment
 
-- Host class: BRIDGE controlled server.
-- Workspace: `/data1` worktree; the public record intentionally omits user and
+- Host class: controlled compute server.
+- Workspace: isolated worktree; the public record intentionally omits user and
   server-specific absolute paths.
 - Python: 3.12.13.
 - Source import: exact worktree for the full suite.

--- a/scripts/check_repository.py
+++ b/scripts/check_repository.py
@@ -26,7 +26,7 @@ EXCLUDED_PARTS = {
     "venv",
 }
 FORBIDDEN_PRIVATE = (
-    re.compile(r"/data[12]/[^/\s\"']+/"),
+    re.compile(r"/(?:data[0-9]+|mnt|srv)/[^/\s\"']+/"),
     re.compile(r"/Users/[^/\s\"']+/"),
     re.compile(r"\\Users\\[^\\\s\"']+\\"),
 )

--- a/src/bridge/tool_packages/cards/P0-11.md
+++ b/src/bridge/tool_packages/cards/P0-11.md
@@ -75,9 +75,10 @@ value bindings, source graph references and renderer metadata are never selected
 Every exported claim requires an approved case alias and every source statement
 reference must be in the policy allowlist.
 
-The fixed second-line scan rejects server/user paths, `bridge-amax`, credential
-or token patterns, email addresses and internal evidence/product/sample/
-preparation refs in the rebuilt report, manifest or result.
+The fixed second-line scan rejects private mount paths, server/user paths,
+internal host declarations, credential or token patterns, email addresses and
+internal evidence/product/sample/preparation refs in the rebuilt report,
+manifest or result.
 
 ## Refusal reason codes
 

--- a/src/bridge/tool_packages/p0_11_public_safe_export/adapter.py
+++ b/src/bridge/tool_packages/p0_11_public_safe_export/adapter.py
@@ -74,10 +74,15 @@ FILENAMES = (
 )
 LEAK_PATTERNS = (
     re.compile(
-        r"(?:/data[12]/|/" r"Users/|/home/|[A-Za-z]:\\Users\\)",
+        r"(?:/(?:data[0-9]+|mnt|srv|private|internal)/|/"
+        r"Users/|/home/|[A-Za-z]:\\Users\\)",
         re.I,
     ),
-    re.compile(r"\bbridge-amax\b", re.I),
+    re.compile(
+        r"\b(?:source|server|compute)\s+host(?:name)?\s*"
+        r"(?:is|[:=])\s*[A-Za-z0-9._-]+\b",
+        re.I,
+    ),
     re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I),
     re.compile(
         r"\b(?:api[_-]?key|password|secret|access[_-]?token|"

--- a/tests/test_environment_contracts.py
+++ b/tests/test_environment_contracts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -96,25 +97,39 @@ def test_evidence_environment_is_self_contained_and_pinned() -> None:
 
 
 def test_active_environment_contracts_do_not_name_machine_local_environments() -> None:
+    paths = sorted((REPO_ROOT / "environments").glob("*"))
+    specs = [
+        yaml.safe_load(path.read_text(encoding="utf-8"))
+        for path in paths
+        if path.suffix in {".yaml", ".yml"}
+    ]
+    named_specs = [spec for spec in specs if isinstance(spec, dict) and "name" in spec]
     text = "\n".join(
-        path.read_text(encoding="utf-8")
-        for path in sorted((REPO_ROOT / "environments").glob("*"))
-        if path.is_file()
+        path.read_text(encoding="utf-8") for path in paths if path.is_file()
     )
 
-    assert "name: pytorch" not in text
-    assert "/data1/" not in text
-    assert "/data2/" not in text
-    assert "/Users/" not in text
+    private_mount = re.compile(r"/(?:data[0-9]+|mnt|srv)/")
+    private_home = re.compile(r"/(?:Users|home)/[^/\s]+/")
+    assert named_specs
+    assert all(str(spec["name"]).startswith("bridge-") for spec in named_specs)
+    assert private_mount.search(text) is None
+    assert private_home.search(text) is None
 
 
 def test_active_tool_docs_use_environment_specs_not_server_environment_names() -> None:
     docs = REPO_ROOT / "docs" / "bridge_spec_v0.1"
     text = "\n".join(path.read_text(encoding="utf-8") for path in sorted(docs.glob("*.md")))
 
-    assert "`pytorch`" not in text
-    assert "`r4.3`" not in text
-    assert "bridge-amax" not in text
+    internal_host = re.compile(
+        r"\b(?:source|server|compute)\s+host(?:name)?\s*(?:is|[:=])\s*\S+",
+        re.I,
+    )
+    machine_environment = re.compile(
+        r"\b(?:server|machine-local)\s+environment(?:\s+name)?\s*(?:is|[:=])\s*\S+",
+        re.I,
+    )
+    assert internal_host.search(text) is None
+    assert machine_environment.search(text) is None
 
 
 def test_cell_state_python_environment_contract_is_pinned() -> None:

--- a/tests/test_knowledge_catalog.py
+++ b/tests/test_knowledge_catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from bridge.toolkit.registry import ToolRegistry
@@ -111,10 +112,11 @@ def test_packaged_snapshot_contains_no_private_paths() -> None:
     registry = KnowledgeRegistry.load_default()
     payload = json.dumps(registry.snapshot, ensure_ascii=False)
 
-    assert "/data1/" not in payload
-    assert "/data2/" not in payload
+    private_mount = re.compile(r"/(?:data[0-9]+|mnt|srv)/")
+    private_home = re.compile(r"/home/[A-Za-z0-9._-]+/")
+    assert private_mount.search(payload) is None
     assert "/Users/" not in payload
-    assert "yuxiao" not in payload.lower()
+    assert private_home.search(payload) is None
 
 
 def test_curated_p0_01_source_corrections_are_present() -> None:

--- a/tests/test_p0_09_evidence_compiler.py
+++ b/tests/test_p0_09_evidence_compiler.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
-from pathlib import Path
+import re
 import traceback
+from pathlib import Path
 from typing import Any
 
 from jsonschema import Draft202012Validator
@@ -1019,7 +1020,11 @@ def test_committed_synthetic_fixtures_validate_without_private_material() -> Non
             missing.model_dump(mode="json"),
         ]
     )
-    assert "/Users/" not in serialized and "/data1/" not in serialized
+    private_path = re.compile(
+        r"(?:/(?:data[0-9]+|mnt|srv|private|internal)/|/"
+        r"Users/|/home/)"
+    )
+    assert private_path.search(serialized) is None
 
 
 def test_case_compilation_publishes_ten_immutable_artifacts_without_formal_promotion(

--- a/tests/test_p0_11_public_safe_export.py
+++ b/tests/test_p0_11_public_safe_export.py
@@ -291,12 +291,12 @@ def test_confirmation_mismatch_fails_without_artifacts(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "text",
     [
-        "Private path /" + "data1/team/run must not be public.",
+        "Private path /" + "mnt/internal-team/run must not be public.",
         "Contact alice@example.org for details.",
         "Credential api_key=super-secret-value is private.",
         "Internal evidence:abcdef must not appear.",
         "Internal sample:private-1 must not appear.",
-        "The source host is bridge-amax.",
+        "The source hostname is compute-node-17.",
     ],
 )
 def test_leak_canaries_fail_closed(tmp_path: Path, text: str) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from bridge.toolkit.contracts import ImplementationState, ToolRequest
@@ -68,9 +69,10 @@ def test_public_registry_payload_contains_no_absolute_paths() -> None:
 
     payload = [spec.model_dump_json() for spec in registry.list()]
 
-    assert "/data1/" not in "".join(payload)
-    assert "/data2/" not in "".join(payload)
-    assert "/Users/" not in "".join(payload)
+    serialized = "".join(payload)
+    private_mount = re.compile(r"/(?:data[0-9]+|mnt|srv)/")
+    assert private_mount.search(serialized) is None
+    assert "/Users/" not in serialized
 
 
 def test_all_public_contract_schemas_are_packaged_and_versioned() -> None:


### PR DESCRIPTION
## Summary

- restore the original BRIDGE expansion before the Agent positioning
- remove machine-specific host, mount, user and runtime identifiers from the current public tree
- generalize repository and public-export leak checks without weakening refusal behavior

**BRIDGE:** Brain-Referenced In vivo-to-in vitro Developmental Guidance and Evaluation  
**Product:** Scientific Agent for cell-therapy product evaluation

## Scope

Documentation, privacy-policy checks and their regression tests. No Python API, CLI, Schema, Tool ID, implementation state, scientific status or PR #17 changes.

## Validation

- 215 focused registry, evidence-compiler and public-export tests passed
- 10 environment-contract tests passed
- repository policy and whitespace checks passed
- GitHub `repository-gates` is the authoritative complete gate
