### PR TITLE
docs: document P0 tool implementations and dependencies

### DIFF
--- a/docs/tool-packages.md
+++ b/docs/tool-packages.md
@@ -1,16 +1,14 @@
 # Tool Package Guide
 
-The 12 high-level P0 tools are the current Agent-callable foundation, not the
-complete BRIDGE product. All are implemented and callable; all remain scientific
-candidates, and P0-02 and downstream domain evidence remain shadow unless their
-versioned scientific authorities are approved. The future Agent will orchestrate
-these packages through the same contracts rather than reproduce their scientific
-logic.
+BRIDGE exposes 12 high-level P0 Tool Packages as the callable capability layer
+for the planned scientific Agent. All are implemented and callable engineering
+candidates. Scientific readiness is tracked separately: downstream evidence
+remains shadow where applicable, and no formal domain score is available.
 
-**Jump to:** [P0-01–P0-02 intake and state evidence](#intake-and-state-evidence) ·
-[P0-03–P0-06 product-domain evidence](#product-domain-evidence) ·
-[P0-07/P0-12 comparison and graft context](#comparison-and-graft-context) ·
-[P0-08–P0-11 evidence governance and export](#evidence-governance-and-export)
+**Jump to:** [P0-01](#p0-01) · [P0-02](#p0-02) · [P0-03](#p0-03) ·
+[P0-04](#p0-04) · [P0-05](#p0-05) · [P0-06](#p0-06) ·
+[P0-07](#p0-07) · [P0-08](#p0-08) · [P0-09](#p0-09) ·
+[P0-10](#p0-10) · [P0-11](#p0-11) · [P0-12](#p0-12)
 
 ```text
 upload → audit → state evidence → domain evidence → sufficiency → graph → verify → export
@@ -19,97 +17,186 @@ upload → audit → state evidence → domain evidence → sufficiency → grap
 P0-07 compares eligible product bundles. P0-12 keeps graft evidence independent.
 ```
 
-## Which document is authoritative?
+## Shared interface
 
-Each package has four deliberately different documentation layers:
-
-1. The package `README.md` is a short landing page for code readers.
-2. The **Tool Card** is the authoritative human-readable runtime contract:
-   input fields and roles, output objects, eligibility, refusal/degradation
-   semantics, examples and scientific boundaries.
-3. The **scientific task card** records the biological question, data and
-   reference assumptions, candidate methods, validation design and literature.
-4. The **validation record** states what was actually tested at a specific
-   implementation version; it is not a scientific release certificate.
-
-Public JSON Schemas remain the machine-readable interface. If an overview and a
-versioned Schema disagree, stop and resolve the discrepancy rather than inferring
-an answer from prose.
-
-Shared calls are:
+The package README is the short code-reader entry point. The **Tool Card** is the
+authoritative human-readable runtime interface. The scientific task card records
+the biological question and validation design. The validation record says what
+was actually tested. Public JSON Schemas and `input-contract` are the
+machine-readable interface; prose does not override them.
 
 ```bash
 bridge-tool describe P0-XX
 bridge-tool input-contract P0-XX
-bridge-tool validate --request /absolute/path/to/request.json
-bridge-tool run --request /absolute/path/to/request.json
+bridge-tool validate --request <request.json>
+bridge-tool run --request <request.json>
 ```
 
-The Python SDK exposes the same `list_tools`, `describe_tool`, `describe_tool_input`,
-`validate_request` and `run_tool` surface. P0-01 and P0-02 use the expression-
-asset `ToolRequest` v0.1 envelope; P0-03 through P0-12 use checksummed local JSON
-objects in `ToolRequestV2`.
+The Python package exposes `list_tools`, `describe_tool`, `describe_tool_input`,
+`validate_request` and `run_tool`. P0-01 and P0-02 use `ToolRequest` v0.1;
+P0-03 through P0-12 use checksummed local JSON objects in `ToolRequestV2`.
 
-## Intake and state evidence
+All modules use the shared BRIDGE contract/runtime layer built on
+[Pydantic](https://docs.pydantic.dev/) and
+[jsonschema](https://python-jsonschema.readthedocs.io/). The software lists below
+name code that the current implementation actually calls. Registered candidates
+are labelled separately and are not active runtime dependencies or selected
+scientific methods.
 
-| Tool | Purpose | Inputs | Primary outputs | Documentation |
-|---|---|---|---|---|
-| **P0-01 Input Audit & QC** | Establish whether an uploaded expression object is structurally and analytically ready. | Declared H5AD, 10x H5 or 10x MTX asset; assay, matrix semantics, sample/capture metadata and MeasurementSpec. | QC readiness profiles, immutable data-view and biological-unit lineage artifacts, raw QC measurements, visualizations and manifest. | [Package](../src/bridge/tool_packages/p0_01_input_qc/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-01.md) · [Task](bridge_spec_v0.1/input_audit_qc_task_card.md) · [Examples](../examples/requests/p0_01_count_ready.json) · [Validation](validation/p0_01_server_integration_20260810.md) |
-| **P0-02 Cell-State Evidence** | Compare QC-qualified product expression with reviewed reference and marker/program channels without forcing a released label. | Expression views, modality, annotation vocabulary, reference candidates and provenance; optional typed P0-01 handoff. | Source-aware Cell-State evidence and optional V3 profile with explicit denominators, uncertainty and lineage bindings; no assigned state or score. | [Package](../src/bridge/tool_packages/p0_02_cell_state/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-02.md) · [Task](bridge_spec_v0.1/cell_state_annotation_task_card.md) · [Example](../examples/requests/p0_02_cell_state.json) · [Validation](validation/p0_02_server_integration_20260811.md) |
+<a id="p0-01"></a>
+## P0-01 Input Audit & QC
 
-P0-02's pseudobulk reference correlation is a reference-similarity summary, not
-replicate-aware differential-expression inference. Its marker/program channel is
-complementary rather than independent because curation sources overlap.
+| Item | Details |
+|---|---|
+| Purpose | Audit an uploaded expression object and establish whether its declared matrix and metadata are ready for downstream analysis. [Scientific task card](bridge_spec_v0.1/input_audit_qc_task_card.md). |
+| Executable implementation | BRIDGE case validation, matrix audit, raw QC metrics and QC-flag generation. [Scrublet](https://github.com/swolock/scrublet) runs only when explicitly requested and eligible. |
+| Software | [AnnData](https://anndata.readthedocs.io/) for H5AD, [Scanpy](https://scanpy.readthedocs.io/) for 10x H5, [SciPy](https://docs.scipy.org/doc/scipy/) for sparse/MTX input, [NumPy](https://numpy.org/doc/), [pandas](https://pandas.pydata.org/docs/) and [Matplotlib](https://matplotlib.org/stable/). CellBender, EmptyDrops, miQC, MultiQC/Cell Ranger, SampleQC, scDblFinder, scQCenrich, scuttle and SoupX are registered candidates and are not called by this adapter. |
+| Input → output | H5AD, 10x H5 or 10x MTX plus assay, matrix semantics, metadata and MeasurementSpec → QC readiness profiles, raw measurements, lineage artifacts, visualizations and manifest. [Tool Card](../src/bridge/tool_packages/cards/P0-01.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-01`; start from the [count-ready](../examples/requests/p0_01_count_ready.json) or [analysis-ready](../examples/requests/p0_01_analysis_ready.json) request. |
+| Current evidence / status | Public scRNA-seq and snRNA-seq objects exercised reading, raw metrics, immutable-input checks and artifact checksums. This establishes QC-readiness behavior, not product quality, safety or release. [Validation](validation/p0_01_server_integration_20260810.md). |
 
-## Product-domain evidence
+<a id="p0-02"></a>
+## P0-02 Cell-State Evidence
 
-| Tool | Purpose | Inputs | Primary outputs | Documentation |
-|---|---|---|---|---|
-| **P0-03 Target Identity & Regional Fidelity** | Aggregate externally defined target-lineage and transcriptomic regional support. | Eleven checksummed objects binding ProductCase, product definition, role map, assessment and Measurement specs, P0-02/P0-01 evidence, vocabulary and reference. | Three configured descriptive ratios plus binding, applicability, reason and provenance records. | [Package](../src/bridge/tool_packages/p0_03_target_regional/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-03.md) · [Task](bridge_spec_v0.1/target_regional_identity_task_card.md) · [Example](../examples/requests/p0_03_target_regional_evidence.json) · [Validation](validation/p0_03_target_regional_20260825.md) |
-| **P0-04 Developmental Compatibility** | Aggregate alignment to an externally confirmed developmental window. | Checksummed ProductCase, product definition, DevelopmentWindowSpec, DevelopmentStateMap, MeasurementSpec and P0-02 profile, with optional declared timepoint series. | `DevelopmentalCompatibilityResult` with window/earlier/later/branch/unresolved composition and explicit unavailable states. | [Package](../src/bridge/tool_packages/p0_04_developmental_compatibility/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-04.md) · [Task](bridge_spec_v0.1/developmental_compatibility_task_card.md) · [Example](../examples/requests/p0_04_developmental_compatibility.json) · [Validation](validation/p0_04_developmental_compatibility_v0.2.md) |
-| **P0-05 Off-target Control** | Account for the whole product under external role and rare-state calibration rules. | Six checksummed objects: ProductCase, product definition, StateRoleMap, OffTargetAssessmentSpec, P0-02 profile and precomputed evidence bundle. | `OffTargetControlProfile` with role composition, unknown reasons, coverage and rare-state detectability states. | [Package](../src/bridge/tool_packages/p0_05_off_target_control/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-05.md) · [Task](bridge_spec_v0.1/off_target_control_task_card.md) · [Example](../examples/requests/p0_05_off_target_control.json) · [Validation](validation/p0_05_off_target_control_20260825.md) |
-| **P0-06 Proliferation & Stress Response** | Aggregate precomputed, stage-conditioned proliferation, stress-response and related review signals. | Seven checksummed objects binding case, product, developmental window, ProgramSpec, P0-02 profile, ProtocolIR and evidence bundle. | `ProliferationStressResponseProfile` and transcriptomic review flags with coverage, LOD, confounding and attribution states. | [Package](../src/bridge/tool_packages/p0_06_proliferation_stress_response/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-06.md) · [Task](bridge_spec_v0.1/proliferation_stress_response_task_card.md) · [Example](../examples/requests/p0_06_proliferation_stress_response.json) · [Validation](validation/p0_06_proliferation_stress_response_20260825.md) |
+| Item | Details |
+|---|---|
+| Purpose | Produce source-aware reference-similarity and marker/program evidence without forcing a released cell-state label. [Scientific task card](bridge_spec_v0.1/cell_state_annotation_task_card.md). |
+| Executable implementation | The main runtime executes BRIDGE pseudobulk reference correlation and marker-program evidence. Separate benchmark adapters can execute [CellTypist](https://celltypist.readthedocs.io/), [scANVI](https://docs.scvi-tools.org/), [SingleR](https://bioconductor.org/packages/SingleR/), [scmap](https://bioconductor.org/packages/scmap/), [Symphony](https://github.com/immunogenomics/symphony) and [scConform](https://bioconductor.org/packages/scConform/); the Agent path does not select them silently. |
+| Software | Python: AnnData, h5py, NumPy, pandas, SciPy, scikit-learn, PyArrow, CellTypist and scvi-tools. R/Bioconductor: SingleR, scmap, symphony, scConform, SingleCellExperiment, SummarizedExperiment, S4Vectors and jsonlite. |
+| Input → output | QC-qualified expression views, modality, vocabulary, references and provenance → source-aware Cell-State evidence, uncertainty and lineage bindings; no released assignment or score. [Tool Card](../src/bridge/tool_packages/cards/P0-02.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-02`; start from the [request example](../examples/requests/p0_02_cell_state.json). Benchmark/freeze commands remain science-team workflows. |
+| Current evidence / status | Real-data integration established a reproducible shadow baseline; the pilot exposed forced-label/OOD and fine-state limitations. Reference correlation is similarity, not replicate-aware differential expression. The method remains unfrozen, `score_state=shadow`, `domain_score=null`. [Integration](validation/p0_02_server_integration_20260811.md) · [Pilot](validation/p0_02_scientific_freeze_pilot_20260811.md). |
 
-These tools bind externally versioned biology and aggregate precomputed evidence.
-They do not hard-code a cell-state map, developmental window, threshold or
-product role, and they emit no spatial-localization, biological-age, safety or
-release conclusion.
+<a id="p0-03"></a>
+## P0-03 Target Identity & Regional Fidelity
 
-## Comparison and graft context
+| Item | Details |
+|---|---|
+| Purpose | Aggregate externally defined target-lineage and transcriptomic regional support. [Scientific task card](bridge_spec_v0.1/target_regional_identity_task_card.md). |
+| Executable implementation | Deterministic StateRoleMap and regional StateRoleMap aggregation; biological roles are supplied, not inferred or embedded. |
+| Software | Shared Pydantic/JSON Schema runtime and Python standard library; no external biological model. |
+| Input → output | Eleven checksummed case, product, role, measurement, QC, state-evidence, vocabulary and reference objects → three descriptive ratios with applicability, reasons and provenance. [Tool Card](../src/bridge/tool_packages/cards/P0-03.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-03`; start from the [request example](../examples/requests/p0_03_target_regional_evidence.json). |
+| Current evidence / status | Synthetic cases verify deterministic ratios, missing-data behavior and checksummed artifacts. Results remain `candidate/shadow`, `domain_score=null`; this is not biological validation of regional identity. [Validation](validation/p0_03_target_regional_20260825.md). |
 
-| Tool | Purpose | Inputs | Primary outputs | Documentation |
-|---|---|---|---|---|
-| **P0-07 Product Comparison & Stability** | Compare cases only when an explicit comparability and confounding contract permits it. | ComparisonStabilitySpec, ComparisonCaseManifest and two to twenty checksummed precomputed product-evidence bundles. | `ProductComparisonStabilityProfile` with comparability state, raw summaries and descriptive deltas/ranges. | [Package](../src/bridge/tool_packages/p0_07_product_comparison_stability/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-07.md) · [Task](bridge_spec_v0.1/product_comparison_stability_task_card.md) · [Example](../examples/requests/p0_07_product_comparison_stability.json) · [Validation](validation/p0_07_product_comparison_stability_v0.2.md) |
-| **P0-12 Optional Graft Assessment** | Keep post-transplant evidence independent from the pre-transplant product profile. | Either no object inputs, or one checksummed GraftCase, GraftAssessmentSpec and precomputed GraftEvidenceBundle. | `GraftAssessmentResult` with `not_provided` or descriptive graft evidence and no pre-transplant backfill. | [Package](../src/bridge/tool_packages/p0_12_graft_assessment/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-12.md) · [Task](bridge_spec_v0.1/graft_assessment_task_card.md) · [Example](../examples/requests/p0_12_graft_assessment.json) · [Validation](validation/p0_12_graft_assessment_20260825.md) |
+<a id="p0-04"></a>
+## P0-04 Developmental Compatibility
 
-P0-07 never declares a winner or equivalence. P0-12 never turns graft evidence
-into a pre-transplant score, threshold, training label or efficacy claim.
+| Item | Details |
+|---|---|
+| Purpose | Aggregate alignment to an externally supplied developmental window. [Scientific task card](bridge_spec_v0.1/developmental_compatibility_task_card.md). |
+| Executable implementation | Deterministic DevelopmentStateMap validation and soft-composition aggregation; no window or state map is hard-coded. |
+| Software | Shared Pydantic/JSON Schema runtime and Python standard library; no external trajectory or age model. |
+| Input → output | ProductCase, product definition, DevelopmentWindowSpec, DevelopmentStateMap, MeasurementSpec and P0-02 profile, optionally with timepoints → `DevelopmentalCompatibilityResult`. [Tool Card](../src/bridge/tool_packages/cards/P0-04.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-04`; start from the [request example](../examples/requests/p0_04_developmental_compatibility.json). |
+| Current evidence / status | Contract fixtures verify deterministic composition and unavailable/refusal states. The package remains `candidate`, `domain_score=null`; it does not freeze a developmental window or biological age. [Validation](validation/p0_04_developmental_compatibility_v0.2.md). |
 
-## Evidence governance and export
+<a id="p0-05"></a>
+## P0-05 Off-target Control
 
-| Tool | Purpose | Inputs | Primary outputs | Documentation |
-|---|---|---|---|---|
-| **P0-08 Evidence Sufficiency** | Apply deterministic Data Readiness, Model Robustness and Prior Applicability gates to existing evidence. | Candidate GateRuleSpec and one to five domain bundles containing versioned measurement, QC, validation, prior and sensitivity records. | Canonical `EvidenceSufficiencyRunResultV2`, per-domain profiles, gate trace and case summary; no new measurement or score. | [Package](../src/bridge/tool_packages/p0_08_evidence_sufficiency/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-08.md) · [Task](bridge_spec_v0.1/evidence_sufficiency_task_card.md) · [Example](../examples/requests/p0_08_evidence_sufficiency.json) · [Validation](validation/p0_08_evidence_sufficiency_20260813.md) |
-| **P0-09 Evidence Compiler & Reconciler** | Compile immutable atomic evidence, explicit missing requirements and versioned conflicts into bounded evidence graphs. | Compilation bundle, P0-08 profiles, EvidenceFamily/Claim/Reconciliation registries and optional bound prior or comparison graphs. | Evidence/requirement/reconciliation record sets, JSON/Parquet graph facts, manifests and seven bounded read-only queries. | [Package](../src/bridge/tool_packages/p0_09_evidence_compiler/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-09.md) · [Task](bridge_spec_v0.1/evidence_compiler_task_card.md) · [Example](../examples/requests/p0_09_evidence_compiler.json) · [Validation](validation/p0_09_evidence_compiler_20260813.md) |
-| **P0-10 Claim Verifier** | Verify that a structured report preserves cited evidence values, states, scope and approved wording. | Exactly four checksummed objects: ReportDraft, P0-09 Case graph manifest, packaged-authority ClaimPolicySpec and StatementRegistry. | One `ClaimVerificationResult` correspondence receipt; no report copy, measurement, score or release permission. | [Package](../src/bridge/tool_packages/p0_10_claim_verifier/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-10.md) · [Task](bridge_spec_v0.1/claim_verifier_task_card.md) · [Example](../examples/requests/p0_10_claim_verifier.json) · [Validation](validation/p0_10_claim_verifier_20260814.md) |
-| **P0-11 Public-safe Export** | Rebuild an eligible structured report through a field allowlist and confirmation-bound local export. | Exactly four checksummed objects: ReportDraft, eligible P0-10 receipt, PublicExportPolicySpec and PublicExportRequest. | Allowlisted `PublicSafeReport`, export manifest and result as immutable local JSON; no upload. | [Package](../src/bridge/tool_packages/p0_11_public_safe_export/README.md) · [Tool Card](../src/bridge/tool_packages/cards/P0-11.md) · [Task](bridge_spec_v0.1/public_safe_export_task_card.md) · [Example](../examples/requests/p0_11_public_safe_export.json) · [Validation](validation/p0_11_public_safe_export_20260825.md) |
+| Item | Details |
+|---|---|
+| Purpose | Account for the whole product under supplied state roles and rare-state calibration rules. [Scientific task card](bridge_spec_v0.1/off_target_control_task_card.md). |
+| Executable implementation | Deterministic role-aware soft composition, unknown accounting, coverage checks and rare-state detectability states. |
+| Software | Shared Pydantic/JSON Schema runtime plus Python numerical and hashing utilities; no external classifier. |
+| Input → output | ProductCase, product definition, StateRoleMap, assessment spec, P0-02 profile and evidence bundle → `OffTargetControlProfile`. [Tool Card](../src/bridge/tool_packages/cards/P0-05.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-05`; start from the [request example](../examples/requests/p0_05_off_target_control.json). |
+| Current evidence / status | Synthetic positive, negative, missing and alert cases verify whole-product accounting and failure semantics. Results remain `candidate/shadow`, `domain_score=null`; they are not safety evidence. [Validation](validation/p0_05_off_target_control_20260825.md). |
 
-`verified` in P0-10 means correspondence to supplied evidence and packaged policy,
-not biological truth. `exported` in P0-11 means a confirmed local JSON bundle was
-written, not that it was uploaded or scientifically released.
+<a id="p0-06"></a>
+## P0-06 Proliferation & Stress Response
+
+| Item | Details |
+|---|---|
+| Purpose | Aggregate precomputed, stage-conditioned proliferation, stress-response and related review signals. [Scientific task card](bridge_spec_v0.1/proliferation_stress_response_task_card.md). |
+| Executable implementation | Deterministic sample/state aggregation plus design, confounding and sensitivity audit. Gene-set scoring is upstream under a supplied ProgramSpec. |
+| Software | Shared Pydantic/JSON Schema runtime and Python standard library; no external gene-set engine is run. |
+| Input → output | Case, product, developmental window, ProgramSpec, P0-02 profile, ProtocolIR and evidence bundle → `ProliferationStressResponseProfile`. [Tool Card](../src/bridge/tool_packages/cards/P0-06.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-06`; start from the [request example](../examples/requests/p0_06_proliferation_stress_response.json). |
+| Current evidence / status | Synthetic cases verify deterministic profiles, alerts and unavailable paths. Results remain `candidate/shadow`, `domain_score=null`; they do not establish cell fitness, safety or potency. [Validation](validation/p0_06_proliferation_stress_response_20260825.md). |
+
+<a id="p0-07"></a>
+## P0-07 Product Comparison & Stability
+
+| Item | Details |
+|---|---|
+| Purpose | Compare product cases only when an explicit comparability and confounding contract permits it. [Scientific task card](bridge_spec_v0.1/product_comparison_stability_task_card.md). |
+| Executable implementation | Deterministic comparability gate, design/confounding check and raw metric deltas/ranges. |
+| Software | Shared Pydantic/JSON Schema runtime and Python standard library; no equivalence or ranking engine. |
+| Input → output | ComparisonStabilitySpec, ComparisonCaseManifest and two to twenty product-evidence bundles → `ProductComparisonStabilityProfile`. [Tool Card](../src/bridge/tool_packages/cards/P0-07.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-07`; start from the [request example](../examples/requests/p0_07_product_comparison_stability.json). |
+| Current evidence / status | Fixtures verify eligibility gates, confounding states and descriptive deltas. The package remains `candidate`, `domain_score=null`; it declares no winner, equivalence or stability claim. [Validation](validation/p0_07_product_comparison_stability_v0.2.md). |
+
+<a id="p0-08"></a>
+## P0-08 Evidence Sufficiency
+
+| Item | Details |
+|---|---|
+| Purpose | Decide whether existing domain evidence is ready for interpretation under a versioned gate specification. [Scientific task card](bridge_spec_v0.1/evidence_sufficiency_task_card.md). |
+| Executable implementation | Deterministic gate executor, packaged rule registry and validator applying Data Readiness → Model Robustness → Prior Applicability → sufficiency. |
+| Software | Shared Pydantic/JSON Schema runtime, Python standard library and packaged JSON rule/reason-code resources. |
+| Input → output | GateRuleSpec plus one to five domain bundles → `EvidenceSufficiencyRunResultV2`, per-domain profiles, gate trace and case summary. [Tool Card](../src/bridge/tool_packages/cards/P0-08.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-08`; start from the [request example](../examples/requests/p0_08_evidence_sufficiency.json). |
+| Current evidence / status | Fixtures verify gate precedence, checksum failure and distinct sufficiency states. The module creates no measurement or score and remains a non-formal candidate. [Validation](validation/p0_08_evidence_sufficiency_20260813.md). |
+
+<a id="p0-09"></a>
+## P0-09 Evidence Compiler & Reconciler
+
+| Item | Details |
+|---|---|
+| Purpose | Compile immutable evidence, explicit missing requirements and versioned conflicts into a bounded evidence graph. [Scientific task card](bridge_spec_v0.1/evidence_compiler_task_card.md). |
+| Executable implementation | Deterministic compiler/reconciler, append-only versioning, graph reconstruction and seven named read-only queries; no arbitrary writes or Cypher. |
+| Software | [NetworkX](https://networkx.org/documentation/stable/) for reconstruction/invariant checks and [PyArrow/Parquet](https://arrow.apache.org/docs/python/) for graph facts, plus the shared runtime. |
+| Input → output | Compilation bundle, P0-08 profiles and EvidenceFamily, Claim and Reconciliation registries → record sets, JSON/Parquet graph facts, Cytoscape elements and manifests. [Tool Card](../src/bridge/tool_packages/cards/P0-09.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-09`; start from the [request example](../examples/requests/p0_09_evidence_compiler.json). |
+| Current evidence / status | Fixtures verify deterministic rebuilds, idempotence, partial rejection, append-only supersession and bounded queries. Missing evidence becomes a requirement; shadow input is not promoted. [Validation](validation/p0_09_evidence_compiler_20260813.md). |
+
+<a id="p0-10"></a>
+## P0-10 Claim Verifier
+
+| Item | Details |
+|---|---|
+| Purpose | Verify that a structured report preserves cited values, units, states, scope and package-approved wording. [Scientific task card](bridge_spec_v0.1/claim_verifier_task_card.md). |
+| Executable implementation | Deterministic claim verification, exact numeric comparison, controlled rendering, packaged rules and typed release-state aggregation over P0-09 queries. |
+| Software | [regex](https://github.com/mrabarnett/mrab-regex) for bounded Unicode matching, Python [Decimal](https://docs.python.org/3/library/decimal.html), Pydantic/jsonschema and the P0-09 query layer. |
+| Input → output | ReportDraft, P0-09 Case graph manifest, packaged ClaimPolicySpec and StatementRegistry → one `ClaimVerificationResult`. [Tool Card](../src/bridge/tool_packages/cards/P0-10.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-10`; start from the [request example](../examples/requests/p0_10_claim_verifier.json). |
+| Current evidence / status | Adversarial fixtures and a package benchmark verify value/wording correspondence, authority binding and fail-closed behavior. `verified` is not biological truth or release permission. [Validation](validation/p0_10_claim_verifier_20260814.md) · [Benchmark](validation/p0_10_claim_verifier_benchmark_v0.1.md). |
+
+<a id="p0-11"></a>
+## P0-11 Public-safe Export
+
+| Item | Details |
+|---|---|
+| Purpose | Rebuild an eligible structured report through a field allowlist and confirmation-bound local export. [Scientific task card](bridge_spec_v0.1/public_safe_export_task_card.md). |
+| Executable implementation | Deterministic allowlist projection, packaged rules, leak-canary scan and immutable local JSON export; no network upload. |
+| Software | Shared Pydantic/JSON Schema runtime plus Python regular-expression, JSON, hashing and filesystem utilities; consumes a P0-10 receipt. |
+| Input → output | ReportDraft, eligible P0-10 receipt, PublicExportPolicySpec and PublicExportRequest → `PublicSafeReport`, export manifest and result. [Tool Card](../src/bridge/tool_packages/cards/P0-11.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-11`; start from the [request example](../examples/requests/p0_11_public_safe_export.json). |
+| Current evidence / status | Fixtures verify confirmation binding, allowlisting, leak-canary checks and immutable local output. A passed scan covers frozen rules/canaries only; `exported` means neither uploaded nor scientifically released. [Validation](validation/p0_11_public_safe_export_20260825.md). |
+
+<a id="p0-12"></a>
+## P0-12 Optional Graft Assessment
+
+| Item | Details |
+|---|---|
+| Purpose | Characterize optional post-transplant graft evidence without feeding it back into the pre-transplant product profile. [Scientific task card](bridge_spec_v0.1/graft_assessment_task_card.md). |
+| Executable implementation | Deterministic GraftCase validation, soft-composition aggregation and explicit no-input handling. |
+| Software | Shared Pydantic/JSON Schema runtime and Python standard library; no external graft-outcome model. |
+| Input → output | No object inputs, or GraftCase, GraftAssessmentSpec and GraftEvidenceBundle → `GraftAssessmentResult` with `not_provided` or descriptive evidence. [Tool Card](../src/bridge/tool_packages/cards/P0-12.md). |
+| Call | Shared CLI/SDK with `tool_id=P0-12`; start from the [request example](../examples/requests/p0_12_graft_assessment.json). |
+| Current evidence / status | Synthetic cases verify aggregation, provenance and `not_provided`. Results remain `candidate/shadow`; they establish neither efficacy, release suitability nor a pre-transplant score. [Validation](validation/p0_12_graft_assessment_20260825.md). |
 
 ## Methods, Schemas and evidence
 
-- `bridge-tool describe P0-XX` is the fastest way to inspect a package version,
-  schemas, environment and registered method IDs.
-- The [catalog-backed method shortlist](../knowledge/active-methods.md) links
-  globally curated methods to their source records. P0-10 additionally owns a
-  versioned [claim-verifier benchmark](validation/p0_10_claim_verifier_benchmark_v0.1.md).
+- `bridge-tool describe P0-XX` reports the installed version, schemas,
+  environment and registered method IDs.
+- `bridge-tool input-contract P0-XX` reports Agent-facing input modes and role
+  cardinality.
+- The [catalog-backed method shortlist](../knowledge/active-methods.md) records
+  candidate methods and sources; catalog presence does not mean execution.
 - The [public Schema directory](../src/bridge/resources/schemas/) defines the
   language-neutral object contracts.
-- Literature in a task card motivates a method or validation design; it does not
-  promote the package, a state definition or a result to formal scientific use.
 
 Across every package, `missing`, `unknown`, `unavailable`, `negative` and `alert`
-remain distinct. A contract failure is not a biological finding, and a valid
-candidate run is not a scientific release.
+remain distinct. A valid candidate run is not a scientific release.

--- a/src/bridge/tool_packages/p0_01_input_qc/README.md
+++ b/src/bridge/tool_packages/p0_01_input_qc/README.md
@@ -12,6 +12,7 @@ This directory contains the executable input-audit and QC package.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-01)
 - [Tool Card — authoritative runtime contract](../cards/P0-01.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/input_audit_qc_task_card.md)
 - [Count-ready request example](../../../../examples/requests/p0_01_count_ready.json)

--- a/src/bridge/tool_packages/p0_02_cell_state/README.md
+++ b/src/bridge/tool_packages/p0_02_cell_state/README.md
@@ -14,6 +14,7 @@ package. Its output remains shadow without a signed release manifest.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-02)
 - [Tool Card — authoritative runtime contract](../cards/P0-02.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/cell_state_annotation_task_card.md)
 - [Request example](../../../../examples/requests/p0_02_cell_state.json)

--- a/src/bridge/tool_packages/p0_03_target_regional/README.md
+++ b/src/bridge/tool_packages/p0_03_target_regional/README.md
@@ -14,6 +14,7 @@ This directory contains the deterministic target and regional evidence package.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-03)
 - [Tool Card — authoritative runtime contract](../cards/P0-03.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/target_regional_identity_task_card.md)
 - [Request example](../../../../examples/requests/p0_03_target_regional_evidence.json)

--- a/src/bridge/tool_packages/p0_04_developmental_compatibility/README.md
+++ b/src/bridge/tool_packages/p0_04_developmental_compatibility/README.md
@@ -14,6 +14,7 @@ This directory contains the deterministic developmental-window evidence package.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-04)
 - [Tool Card — authoritative runtime contract](../cards/P0-04.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/developmental_compatibility_task_card.md)
 - [Request example](../../../../examples/requests/p0_04_developmental_compatibility.json)

--- a/src/bridge/tool_packages/p0_05_off_target_control/README.md
+++ b/src/bridge/tool_packages/p0_05_off_target_control/README.md
@@ -13,6 +13,7 @@ This directory contains the deterministic whole-product role-accounting package.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-05)
 - [Tool Card — authoritative runtime contract](../cards/P0-05.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/off_target_control_task_card.md)
 - [Request example](../../../../examples/requests/p0_05_off_target_control.json)

--- a/src/bridge/tool_packages/p0_06_proliferation_stress_response/README.md
+++ b/src/bridge/tool_packages/p0_06_proliferation_stress_response/README.md
@@ -13,6 +13,7 @@ This directory contains the deterministic program-evidence aggregation package.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-06)
 - [Tool Card — authoritative runtime contract](../cards/P0-06.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/proliferation_stress_response_task_card.md)
 - [Request example](../../../../examples/requests/p0_06_proliferation_stress_response.json)

--- a/src/bridge/tool_packages/p0_07_product_comparison_stability/README.md
+++ b/src/bridge/tool_packages/p0_07_product_comparison_stability/README.md
@@ -14,6 +14,7 @@ package.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-07)
 - [Tool Card — authoritative runtime contract](../cards/P0-07.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/product_comparison_stability_task_card.md)
 - [Request example](../../../../examples/requests/p0_07_product_comparison_stability.json)

--- a/src/bridge/tool_packages/p0_08_evidence_sufficiency/README.md
+++ b/src/bridge/tool_packages/p0_08_evidence_sufficiency/README.md
@@ -13,6 +13,7 @@ This directory contains the deterministic evidence-gating package.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-08)
 - [Tool Card — authoritative runtime contract](../cards/P0-08.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/evidence_sufficiency_task_card.md)
 - [Request example](../../../../examples/requests/p0_08_evidence_sufficiency.json)

--- a/src/bridge/tool_packages/p0_09_evidence_compiler/README.md
+++ b/src/bridge/tool_packages/p0_09_evidence_compiler/README.md
@@ -14,6 +14,7 @@ package.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-09)
 - [Tool Card — authoritative runtime contract](../cards/P0-09.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/evidence_compiler_task_card.md)
 - [Request example](../../../../examples/requests/p0_09_evidence_compiler.json)

--- a/src/bridge/tool_packages/p0_10_claim_verifier/README.md
+++ b/src/bridge/tool_packages/p0_10_claim_verifier/README.md
@@ -13,6 +13,7 @@ This directory contains the deterministic structured-claim verification package.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-10)
 - [Tool Card — authoritative runtime contract](../cards/P0-10.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/claim_verifier_task_card.md)
 - [Request example](../../../../examples/requests/p0_10_claim_verifier.json)

--- a/src/bridge/tool_packages/p0_11_public_safe_export/README.md
+++ b/src/bridge/tool_packages/p0_11_public_safe_export/README.md
@@ -13,6 +13,7 @@ This directory contains the deterministic allowlist-based JSON export package.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-11)
 - [Tool Card — authoritative runtime contract](../cards/P0-11.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/public_safe_export_task_card.md)
 - [Request example](../../../../examples/requests/p0_11_public_safe_export.json)

--- a/src/bridge/tool_packages/p0_12_graft_assessment/README.md
+++ b/src/bridge/tool_packages/p0_12_graft_assessment/README.md
@@ -13,6 +13,7 @@ This directory contains the independent, optional graft-evidence package.
 
 ## Documentation
 
+- [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-12)
 - [Tool Card — authoritative runtime contract](../cards/P0-12.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/graft_assessment_task_card.md)
 - [Request example](../../../../examples/requests/p0_12_graft_assessment.json)


### PR DESCRIPTION
## What changed

- replace the grouped P0 overview with one concise implementation table per Tool Package
- distinguish code the current adapter actually executes from methods that are only registered candidates
- document module-specific software, input/output flow, CLI/SDK entry points, request examples and current evidence
- link each package README back to its canonical implementation summary

## Evidence and scientific status

Each table separates verified engineering behavior from scientific readiness. Test passage is not presented as biological performance; candidate/shadow status and unavailable domain scores remain explicit. Existing P0-02 pilot and P0-10 benchmark records are linked rather than copied.

## Validation

- 12 package specs report `implementation_state: implemented`
- exact-commit wheel installation: 12/12 `describe`, 12/12 `input-contract`, and SDK 12-tool discovery passed
- all local document targets, explicit anchors and external software links resolved
- repository policy, knowledge validation and diff checks passed
- tracked-content privacy scan found no internal host, path, environment or credential material in the change

No CLI, Python interface, Schema, Tool ID, dependency or scientific authority changed. PR #17 is untouched.
