### PR TITLE
fix: validate P0-10 raw inputs with jsonschema

### DIFF
--- a/docs/bridge_spec_v0.1/claim_verifier_task_card.md
+++ b/docs/bridge_spec_v0.1/claim_verifier_task_card.md
@@ -9,7 +9,7 @@
 | Primary output | `ClaimVerificationResult` receipt |
 | Current state | `candidate` |
 
-P0-10 `v0.1.0` implements the structured deterministic path only. Its four
+P0-10 `v0.1.1` implements the structured deterministic path only. Its four
 checksummed inputs are `ReportDraft`, a P0-09 Case graph manifest,
 `ClaimPolicySpec` and
 `StatementRegistry`. The supplied policy and statement objects must equal the

--- a/docs/tool-packages.md
+++ b/docs/tool-packages.md
@@ -157,11 +157,11 @@ scientific methods.
 | Item | Details |
 |---|---|
 | Purpose | Verify that a structured report preserves cited values, units, states, scope and package-approved wording. [Scientific task card](bridge_spec_v0.1/claim_verifier_task_card.md). |
-| Executable implementation | Deterministic claim verification, exact numeric comparison, controlled rendering, packaged rules and typed release-state aggregation over P0-09 queries. |
+| Executable implementation | Independent Draft 2020-12 validation of the four raw JSON inputs, deterministic claim verification, exact numeric comparison, controlled rendering, packaged rules and typed release-state aggregation over P0-09 queries. |
 | Software | [regex](https://github.com/mrabarnett/mrab-regex) for bounded Unicode matching, Python [Decimal](https://docs.python.org/3/library/decimal.html), Pydantic/jsonschema and the P0-09 query layer. |
 | Input → output | ReportDraft, P0-09 Case graph manifest, packaged ClaimPolicySpec and StatementRegistry → one `ClaimVerificationResult`. [Tool Card](../src/bridge/tool_packages/cards/P0-10.md). |
 | Call | Shared CLI/SDK with `tool_id=P0-10`; start from the [request example](../examples/requests/p0_10_claim_verifier.json). |
-| Current evidence / status | Adversarial fixtures and a package benchmark verify value/wording correspondence, authority binding and fail-closed behavior. `verified` is not biological truth or release permission. [Validation](validation/p0_10_claim_verifier_20260814.md) · [Benchmark](validation/p0_10_claim_verifier_benchmark_v0.1.md). |
+| Current evidence / status | Adversarial fixtures and a package benchmark verify value/wording correspondence, authority binding and fail-closed behavior. `verified` is not biological truth or release permission. [Validation](validation/p0_10_claim_verifier_20260814.md) · [JSON Schema runtime](validation/p0_10_jsonschema_runtime_20260827.md) · [Benchmark](validation/p0_10_claim_verifier_benchmark_v0.1.md). |
 
 <a id="p0-11"></a>
 ## P0-11 Public-safe Export

--- a/docs/validation/p0_10_jsonschema_runtime_20260827.md
+++ b/docs/validation/p0_10_jsonschema_runtime_20260827.md
@@ -1,0 +1,32 @@
+# P0-10 raw JSON Schema runtime validation (2026-08-27)
+
+- Branch: `p0-10-jsonschema-validation`
+- Integration base: `d749e8b3a05ffe9c4461312e8eb01b3fd32eb492`
+- Package: `P0-10 0.1.1`
+- Runtime: Ubuntu, Python 3.12, `ENV-EVIDENCE-v0.1`
+- Scientific state: `candidate`; no biological truth or release authority
+
+## Closed gap
+
+P0-10 already registered `jsonschema` as an approved structured-contract method,
+but runtime input loading previously relied on Pydantic alone. The adapter now
+runs `jsonschema.Draft202012Validator` against the exact decoded payload of each
+of its four checksummed input objects before Pydantic model validation. Invalid
+raw input returns the existing `structured_input_schema_invalid` reason code.
+The CLI, SDK, roles and result Schema are unchanged.
+
+## Verification
+
+- focused P0-10 and registry suite: **70 passed**;
+- complete repository suite: **1,227 passed**, with eight pre-existing dependency warnings;
+- wheel-only schema-call and successful-receipt smoke: **2 passed**;
+- installed module resolved from the unpacked wheel outside the source tree;
+- wheel SHA-256: `0ea309f58f2064594c07a23bf0fd1d1f930752b891924b707fe2cdea1531a4f9`;
+- generated Tool Card, knowledge validation, repository policy and diff hygiene: passed.
+
+## Boundary
+
+JSON Schema validation establishes contract conformance only. Claim verification
+still checks correspondence to supplied evidence and package authority; it does
+not establish biological truth, efficacy, safety, potency, GMP release or public
+release permission.

--- a/examples/requests/p0_10_claim_verifier.json
+++ b/examples/requests/p0_10_claim_verifier.json
@@ -44,5 +44,5 @@
   "random_seed": 0,
   "request_id": "example-p0-10-documentation-only",
   "tool_id": "P0-10",
-  "tool_version": "0.1.0"
+  "tool_version": "0.1.1"
 }

--- a/src/bridge/tool_packages/cards/P0-10.md
+++ b/src/bridge/tool_packages/cards/P0-10.md
@@ -9,7 +9,7 @@ denominator, interval, evidence state, comparison scope and approved wording.
 
 | Field | Value |
 |---|---|
-| Package version | `0.1.0` |
+| Package version | `0.1.1` |
 | Runtime state | `implemented` |
 | Scientific state | `candidate` |
 | Optional | `no` |
@@ -53,16 +53,17 @@ or checksum mismatch produces a failed run with a typed reason code.
 
 The verifier runs these checks in a fixed order:
 
-1. Report hash, four-object binding and complete P0-09 graph integrity.
-2. Claim/ProductCase-to-Evidence and Statement references.
-3. Evidence lifecycle, applicability, tier and reported state.
-4. One-field/one-span identity `Decimal` bindings for each rendered value,
+1. Exact-byte checksums, independent Draft 2020-12 JSON Schema validation, object versions and four-object binding.
+2. Report hash and complete P0-09 graph integrity.
+3. Claim/ProductCase-to-Evidence and Statement references.
+4. Evidence lifecycle, applicability, tier and reported state.
+5. One-field/one-span identity `Decimal` bindings for each rendered value,
    unit, denominator or interval endpoint.
-5. Complete package-owned ClaimBlock reconstruction and
+6. Complete package-owned ClaimBlock reconstruction and
    descriptive-versus-inferential comparison scope.
-6. Bounded Unicode bilingual policy patterns and exact Statement exceptions.
-7. Whole-report private-content checks and packaged policy/statement authority.
-8. Release-state aggregation; public candidates always require formal Evidence.
+7. Bounded Unicode bilingual policy patterns and exact Statement exceptions.
+8. Whole-report private-content checks and packaged policy/statement authority.
+9. Release-state aggregation; public candidates always require formal Evidence.
 
 A caller-supplied human decision cannot clear any result in v0.1. LLM judgment,
 OPA, free-Markdown
@@ -132,6 +133,8 @@ blocker, review item or warning. No private path, old score report or P0-02
 controlled data enters the benchmark. The selected default remains unset.
 
 Server evidence: [P0-10 candidate validation, 2026-08-14](https://github.com/starvingarc/BRIDGE/blob/main/docs/validation/p0_10_claim_verifier_20260814.md).
+
+Runtime closure: `docs/validation/p0_10_jsonschema_runtime_20260827.md`.
 
 Detailed requirement:
 `docs/bridge_spec_v0.1/claim_verifier_task_card.md`.

--- a/src/bridge/tool_packages/p0_10_claim_verifier/README.md
+++ b/src/bridge/tool_packages/p0_10_claim_verifier/README.md
@@ -18,6 +18,7 @@ This directory contains the deterministic structured-claim verification package.
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/claim_verifier_task_card.md)
 - [Request example](../../../../examples/requests/p0_10_claim_verifier.json)
 - [Validation record](../../../../docs/validation/p0_10_claim_verifier_20260814.md)
+- [Raw JSON Schema runtime validation](../../../../docs/validation/p0_10_jsonschema_runtime_20260827.md)
 - [Package-owned method benchmark](../../../../docs/validation/p0_10_claim_verifier_benchmark_v0.1.md)
 
 Use `bridge-tool describe P0-10` for the installed version, schemas, environment

--- a/src/bridge/tool_packages/p0_10_claim_verifier/adapter.py
+++ b/src/bridge/tool_packages/p0_10_claim_verifier/adapter.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError, ValidationError
 
 from bridge.tool_packages._structured_runtime import (
     LoadedInputs,
     PublicationError,
+    StructuredInputError,
     canonical_json_bytes,
     directory_state,
     failed_v2_run,
@@ -50,6 +55,7 @@ from bridge.toolkit.contracts import (
     ToolRequestV2,
     ToolRunV2,
 )
+from bridge.toolkit.schemas import load_schema
 
 RESULT_SCHEMA_REF = "bridge://schemas/claim-verification-result/v0.1"
 ROLE_MODELS: dict[str, tuple[str, type[FrozenModel]]] = {
@@ -249,8 +255,18 @@ def _load_inputs(
     return load_structured_inputs(
         refs,
         model_for=lambda ref: ROLE_MODELS.get(ref.role, ("", None))[1],
+        validate_payload=_validate_json_schema,
         validate_model=_validate_object_version,
     )
+
+
+def _validate_json_schema(ref: StructuredInputRef, payload: Any) -> None:
+    try:
+        schema = load_schema(ref.schema_ref)
+        Draft202012Validator.check_schema(schema)
+        Draft202012Validator(schema).validate(payload)
+    except (KeyError, FileNotFoundError, SchemaError, ValidationError):
+        raise StructuredInputError("structured_input_schema_invalid") from None
 
 
 def _validate_object_version(ref: StructuredInputRef, value: FrozenModel) -> None:
@@ -260,8 +276,6 @@ def _validate_object_version(ref: StructuredInputRef, value: FrozenModel) -> Non
         else getattr(value, "object_version", None)
     )
     if version != ref.object_version:
-        from bridge.tool_packages._structured_runtime import StructuredInputError
-
         raise StructuredInputError("object_input_version_mismatch")
 
 

--- a/src/bridge/tool_packages/specs/p0_10.yaml
+++ b/src/bridge/tool_packages/specs/p0_10.yaml
@@ -1,6 +1,6 @@
 tool_id: P0-10
 name: Claim Verifier
-version: 0.1.0
+version: 0.1.1
 summary: Verify that structured report claims, values and wording match approved evidence and policy.
 implementation_state: implemented
 scientific_status: candidate

--- a/tests/test_p0_10_claim_verifier.py
+++ b/tests/test_p0_10_claim_verifier.py
@@ -344,7 +344,7 @@ def _request(
     return ToolRequestV2(
         request_id="request-p0-10",
         tool_id="P0-10",
-        tool_version="0.1.0",
+        tool_version="0.1.1",
         output_dir=tmp_path / "output",
         object_inputs=refs,
     )
@@ -361,6 +361,39 @@ def test_public_models_emit_valid_draft_2020_12_schemas(schema_ref: str, model: 
     schema = model.model_json_schema()
     schema["$id"] = schema_ref
     Draft202012Validator.check_schema(schema)
+
+
+def test_runtime_validates_each_raw_input_with_jsonschema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    runtime_validator = adapter_module.Draft202012Validator
+
+    class TrackingValidator:
+        @classmethod
+        def check_schema(cls, schema: dict[str, Any]) -> None:
+            runtime_validator.check_schema(schema)
+
+        def __init__(self, schema: dict[str, Any]) -> None:
+            calls.append(schema["$id"])
+            self.validator = runtime_validator(schema)
+
+        def validate(self, payload: Any) -> None:
+            self.validator.validate(payload)
+
+    monkeypatch.setattr(
+        adapter_module,
+        "Draft202012Validator",
+        TrackingValidator,
+    )
+
+    eligibility = adapter.check_eligibility(_request(tmp_path), _spec())
+
+    assert eligibility.eligible
+    assert sorted(calls) == sorted(
+        schema_ref for schema_ref, _model in adapter_module.ROLE_MODELS.values()
+    )
 
 
 def test_benchmark_is_task_grouped_complete_and_has_no_default_or_aggregate() -> None:


### PR DESCRIPTION
## Closed runtime gap

P0-10 already registered `jsonschema` as an approved method, but its runtime loader only exercised Pydantic. This change validates each of the four exact decoded input payloads with `jsonschema.Draft202012Validator` before Pydantic model construction.

## Interface

- bumps P0-10 from `0.1.0` to `0.1.1`
- keeps the four input roles, CLI/SDK, result Schema and output unchanged
- reuses the existing `structured_input_schema_invalid` refusal code
- preserves checksum, object-version and graph-integrity checks

## Validation

- focused P0-10 and registry suite: 70 passed
- complete repository suite: 1,227 passed
- wheel-only runtime-schema and successful-receipt smoke: 2 passed
- repository policy, knowledge validation, Tool Card generation and diff hygiene passed
- wheel SHA-256: `0ea309f58f2064594c07a23bf0fd1d1f930752b891924b707fe2cdea1531a4f9`

## Boundary

This closes an engineering contract-validation gap. It does not change claim policy, scientific evidence, release authority or the meaning of `verified`.

Draft for review; not authorized for merge.