### PR TITLE
feat: project P0-05 measurements

### DIFF
--- a/docs/bridge_spec_v0.1/off_target_control_task_card.md
+++ b/docs/bridge_spec_v0.1/off_target_control_task_card.md
@@ -7,7 +7,7 @@
 | 日期 | 2026-08-25 |
 | 状态 | `candidate / executable shadow` |
 | 上游 | P0-02 V2/V3、预计算 evidence bundle 与可选方法运行对象 |
-| 输出 | `OffTargetControlProfile v0.1`；方法模式另含 `OffTargetMethodBundle v0.1`；两种模式均含 typed visualization data、精确 TSV 与静态图 |
+| 输出 | `OffTargetControlProfile v0.2`；可选 checksummed `MeasurementResultV2`；方法模式另含 `OffTargetMethodBundle v0.1`；两种模式均含 typed visualization data、精确 TSV 与静态图 |
 
 ## 1. 生物学问题与当前边界
 
@@ -57,6 +57,7 @@ GMP 放行或产品排序结论。
 | `biological_unit_manifest` | 方法 | reviewed analysis-unit 与 independence-group mapping |
 | `off_target_method_spec` | 方法 | 方法选择、置信度、bootstrap 次数、planning target、OOD channel→family→upstream hash/method/reference 绑定与规则 |
 | `off_target_method_input` | 方法 | unit-level soft/hard composition、spike-in trials、仅含 channel ID/state/reason 的 OOD observations |
+| `measurement_spec` | 两者可选 | MeasurementSpecV2；须绑定 ProductCase、assay、P0-05 和三类允许的投影 metric |
 
 `OffTargetEvidenceBundle` 是上游计算结果的最小交接面。它包含 soft mass 与
 observed count，但不携带角色判断。完整覆盖状态下，state 与 unknown 的 soft
@@ -87,6 +88,10 @@ mass 和 count 必须分别闭合到声明分母；部分覆盖必须显式标�
 `ToolRunV2.result` 返回；方法模式原子增加
 `off_target_method_bundle.json`。
 
+P0-05 v0.5 始终返回 profile v0.2。未提供 MeasurementSpec 时明确记录
+`not_requested` 且不生成 normalized measurement；提供并通过校验时，每条现有
+role、unknown 和 rare-state 记录各生成一个 checksummed MeasurementResultV2。
+
 | 字段 | 含义 |
 |---|---|
 | upstream refs/hashes | ProductCase、Card、RoleMap、AssessmentSpec、P0-02 profile 与 evidence bundle 的精确绑定 |
@@ -97,6 +102,7 @@ mass 和 count 必须分别闭合到声明分母；部分覆盖必须显式标�
 | `reason_codes` | coverage、零观测、缺观测和校准限制 |
 | `evidence_state` | 固定 `shadow` |
 | `score_state` / `domain_score` | 固定 `unavailable` / `null` |
+| measurement projection | 缺失或不可用保持 null，不补零；所有结果仍为 `score_state=unavailable` / `domain_score=null` |
 
 方法 bundle 另含：
 

--- a/examples/requests/p0_05_off_target_control.json
+++ b/examples/requests/p0_05_off_target_control.json
@@ -89,5 +89,5 @@
   "random_seed": 0,
   "request_id": "example-p0-05-documentation-only",
   "tool_id": "P0-05",
-  "tool_version": "0.4.0"
+  "tool_version": "0.5.0"
 }

--- a/scripts/check_repository.py
+++ b/scripts/check_repository.py
@@ -95,6 +95,10 @@ P005_VISUALIZATION_FILES = (
     Path("src/bridge/tool_packages/p0_05_off_target_control/visualization.py"),
     Path("src/bridge/tool_packages/p0_05_off_target_control/visualization_data.py"),
 )
+P005_MEASUREMENT_PROJECTION_FILES = (
+    Path("src/bridge/resources/schemas/off_target_control_profile_v2.schema.json"),
+    Path("src/bridge/tool_packages/p0_05_off_target_control/executor.py"),
+)
 P006_VISUALIZATION_FILES = (
     Path("src/bridge/resources/schemas/proliferation_stress_visualization_data.schema.json"),
     Path("src/bridge/resources/schemas/p0_06_visualization_artifact_set.schema.json"),
@@ -223,6 +227,10 @@ def _tracked_file_budget() -> int:
         (ROOT / relative).is_file()
         for relative in P005_VISUALIZATION_FILES
     )
+    p005_measurement_projection_files = sum(
+        (ROOT / relative).is_file()
+        for relative in P005_MEASUREMENT_PROJECTION_FILES
+    )
     p006_visualization_files = sum(
         (ROOT / relative).is_file()
         for relative in P006_VISUALIZATION_FILES
@@ -243,6 +251,7 @@ def _tracked_file_budget() -> int:
         TRACKED_FILE_BASELINE
         + p004_visualization_files
         + p005_visualization_files
+        + p005_measurement_projection_files
         + p006_visualization_files
         + p007_visualization_files
         + p008_visualization_files

--- a/src/bridge/resources/schemas/off_target_control_profile_v2.schema.json
+++ b/src/bridge/resources/schemas/off_target_control_profile_v2.schema.json
@@ -1,0 +1,683 @@
+{
+  "$defs": {
+    "AssessmentState": {
+      "enum": [
+        "available",
+        "not_assessed"
+      ],
+      "title": "AssessmentState",
+      "type": "string"
+    },
+    "CoverageState": {
+      "enum": [
+        "complete",
+        "partial",
+        "not_assessed"
+      ],
+      "title": "CoverageState",
+      "type": "string"
+    },
+    "EvidenceState": {
+      "enum": [
+        "measured",
+        "inferred",
+        "prior_only",
+        "negative",
+        "missing",
+        "unknown",
+        "unavailable",
+        "alert"
+      ],
+      "title": "EvidenceState",
+      "type": "string"
+    },
+    "ExclusionState": {
+      "enum": [
+        "observed",
+        "cannot_exclude"
+      ],
+      "title": "ExclusionState",
+      "type": "string"
+    },
+    "OffTargetDenominator": {
+      "additionalProperties": false,
+      "properties": {
+        "denominator_id": {
+          "pattern": "^[A-Za-z][A-Za-z0-9._:-]*$",
+          "title": "Denominator Id",
+          "type": "string"
+        },
+        "n_observations": {
+          "exclusiveMinimum": 0,
+          "title": "N Observations",
+          "type": "integer"
+        },
+        "total_soft_mass": {
+          "exclusiveMinimum": 0.0,
+          "title": "Total Soft Mass",
+          "type": "number"
+        },
+        "unit": {
+          "const": "cells",
+          "title": "Unit",
+          "type": "string"
+        }
+      },
+      "required": [
+        "denominator_id",
+        "n_observations",
+        "total_soft_mass",
+        "unit"
+      ],
+      "title": "OffTargetDenominator",
+      "type": "object"
+    },
+    "OffTargetMeasurementArtifactBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "artifact_id": {
+          "minLength": 1,
+          "title": "Artifact Id",
+          "type": "string"
+        },
+        "evidence_state": {
+          "$ref": "#/$defs/EvidenceState"
+        },
+        "file_name": {
+          "pattern": "^[a-z0-9][a-z0-9_.-]*\\.json$",
+          "title": "File Name",
+          "type": "string"
+        },
+        "measurement_id": {
+          "minLength": 1,
+          "title": "Measurement Id",
+          "type": "string"
+        },
+        "metric_name": {
+          "enum": [
+            "off_target_role_composition",
+            "off_target_identity_unknown",
+            "off_target_rare_state_detection"
+          ],
+          "title": "Metric Name",
+          "type": "string"
+        },
+        "record_id": {
+          "pattern": "^[A-Za-z][A-Za-z0-9._:-]*$",
+          "title": "Record Id",
+          "type": "string"
+        },
+        "record_scope": {
+          "enum": [
+            "role",
+            "identity_unknown",
+            "rare_state"
+          ],
+          "title": "Record Scope",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "measurement_id",
+        "metric_name",
+        "record_scope",
+        "record_id",
+        "evidence_state",
+        "artifact_id",
+        "file_name",
+        "sha256"
+      ],
+      "title": "OffTargetMeasurementArtifactBinding",
+      "type": "object"
+    },
+    "ProductRole": {
+      "enum": [
+        "target",
+        "acceptable_adjacent",
+        "known_off_target",
+        "role_unresolved"
+      ],
+      "title": "ProductRole",
+      "type": "string"
+    },
+    "RareDetectionState": {
+      "enum": [
+        "detected",
+        "not_detected_above_lod",
+        "cannot_exclude",
+        "not_assessed"
+      ],
+      "title": "RareDetectionState",
+      "type": "string"
+    },
+    "RareStateRecord": {
+      "additionalProperties": false,
+      "properties": {
+        "calibration_ref": {
+          "anyOf": [
+            {
+              "pattern": "^[A-Za-z][A-Za-z0-9._:-]*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Calibration Ref"
+        },
+        "calibration_sha256": {
+          "anyOf": [
+            {
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Calibration Sha256"
+        },
+        "detection_state": {
+          "$ref": "#/$defs/RareDetectionState"
+        },
+        "false_positive_fraction": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "False Positive Fraction"
+        },
+        "observed_count": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Observed Count"
+        },
+        "reason_codes": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Reason Codes",
+          "type": "array"
+        },
+        "soft_fraction": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Soft Fraction"
+        },
+        "state_id": {
+          "pattern": "^[A-Za-z][A-Za-z0-9._:-]*$",
+          "title": "State Id",
+          "type": "string"
+        },
+        "validated_detection_limit_fraction": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Validated Detection Limit Fraction"
+        },
+        "zero_observation_upper_bound_fraction": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Zero Observation Upper Bound Fraction"
+        }
+      },
+      "required": [
+        "state_id",
+        "observed_count",
+        "soft_fraction",
+        "detection_state",
+        "reason_codes"
+      ],
+      "title": "RareStateRecord",
+      "type": "object"
+    },
+    "RoleCompositionRecord": {
+      "additionalProperties": false,
+      "properties": {
+        "assessment_state": {
+          "$ref": "#/$defs/AssessmentState"
+        },
+        "exclusion_state": {
+          "$ref": "#/$defs/ExclusionState"
+        },
+        "fraction": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Fraction"
+        },
+        "observed_count": {
+          "title": "Observed Count",
+          "type": "integer"
+        },
+        "product_role": {
+          "$ref": "#/$defs/ProductRole"
+        },
+        "soft_mass": {
+          "title": "Soft Mass",
+          "type": "number"
+        }
+      },
+      "required": [
+        "product_role",
+        "soft_mass",
+        "observed_count",
+        "fraction",
+        "assessment_state",
+        "exclusion_state"
+      ],
+      "title": "RoleCompositionRecord",
+      "type": "object"
+    },
+    "UnknownProfile": {
+      "additionalProperties": false,
+      "properties": {
+        "coverage_state": {
+          "$ref": "#/$defs/CoverageState"
+        },
+        "exclusion_state": {
+          "$ref": "#/$defs/ExclusionState"
+        },
+        "fraction": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Fraction"
+        },
+        "observed_count": {
+          "title": "Observed Count",
+          "type": "integer"
+        },
+        "reasons": {
+          "items": {
+            "$ref": "#/$defs/UnknownReasonRecord"
+          },
+          "title": "Reasons",
+          "type": "array"
+        },
+        "soft_mass": {
+          "title": "Soft Mass",
+          "type": "number"
+        }
+      },
+      "required": [
+        "coverage_state",
+        "soft_mass",
+        "observed_count",
+        "fraction",
+        "exclusion_state",
+        "reasons"
+      ],
+      "title": "UnknownProfile",
+      "type": "object"
+    },
+    "UnknownReasonRecord": {
+      "additionalProperties": false,
+      "properties": {
+        "fraction": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Fraction"
+        },
+        "observed_count": {
+          "title": "Observed Count",
+          "type": "integer"
+        },
+        "reason_id": {
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "title": "Reason Id",
+          "type": "string"
+        },
+        "soft_mass": {
+          "title": "Soft Mass",
+          "type": "number"
+        }
+      },
+      "required": [
+        "reason_id",
+        "soft_mass",
+        "observed_count",
+        "fraction"
+      ],
+      "title": "UnknownReasonRecord",
+      "type": "object"
+    },
+    "VersionedObjectRef": {
+      "additionalProperties": false,
+      "properties": {
+        "object_id": {
+          "pattern": "^[A-Za-z][A-Za-z0-9._:-]*$",
+          "title": "Object Id",
+          "type": "string"
+        },
+        "object_version": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+          "title": "Object Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "object_id",
+        "object_version"
+      ],
+      "title": "VersionedObjectRef",
+      "type": "object"
+    }
+  },
+  "$id": "bridge://schemas/off-target-control-profile/v0.2",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "measurement_projection_state": {
+            "const": "not_requested"
+          }
+        },
+        "required": [
+          "measurement_projection_state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "measurement_artifacts": {
+            "maxItems": 0
+          },
+          "measurement_spec_ref": {
+            "type": "null"
+          },
+          "measurement_spec_sha256": {
+            "type": "null"
+          }
+        },
+        "required": [
+          "measurement_artifacts"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "measurement_projection_state": {
+            "const": "available"
+          }
+        },
+        "required": [
+          "measurement_projection_state"
+        ]
+      },
+      "then": {
+        "properties": {
+          "measurement_artifacts": {
+            "minItems": 1
+          },
+          "measurement_spec_ref": {
+            "not": {
+              "type": "null"
+            }
+          },
+          "measurement_spec_sha256": {
+            "not": {
+              "type": "null"
+            }
+          }
+        },
+        "required": [
+          "measurement_spec_ref",
+          "measurement_spec_sha256",
+          "measurement_artifacts"
+        ]
+      }
+    }
+  ],
+  "properties": {
+    "assessment_spec_ref": {
+      "title": "Assessment Spec Ref",
+      "type": "string"
+    },
+    "assessment_spec_sha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Assessment Spec Sha256",
+      "type": "string"
+    },
+    "cell_state_profile_id": {
+      "title": "Cell State Profile Id",
+      "type": "string"
+    },
+    "cell_state_profile_sha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Cell State Profile Sha256",
+      "type": "string"
+    },
+    "created_at": {
+      "format": "date-time",
+      "title": "Created At",
+      "type": "string"
+    },
+    "domain_score": {
+      "default": null,
+      "title": "Domain Score",
+      "type": "null"
+    },
+    "evidence_bundle_ref": {
+      "title": "Evidence Bundle Ref",
+      "type": "string"
+    },
+    "evidence_bundle_sha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Evidence Bundle Sha256",
+      "type": "string"
+    },
+    "evidence_state": {
+      "const": "shadow",
+      "title": "Evidence State",
+      "type": "string"
+    },
+    "measurement_artifacts": {
+      "items": {
+        "$ref": "#/$defs/OffTargetMeasurementArtifactBinding"
+      },
+      "title": "Measurement Artifacts",
+      "type": "array"
+    },
+    "measurement_projection_state": {
+      "enum": [
+        "not_requested",
+        "available"
+      ],
+      "title": "Measurement Projection State",
+      "type": "string"
+    },
+    "measurement_spec_ref": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/VersionedObjectRef"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "measurement_spec_sha256": {
+      "anyOf": [
+        {
+          "pattern": "^[0-9a-f]{64}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Measurement Spec Sha256"
+    },
+    "object_version": {
+      "const": "0.2.0",
+      "title": "Object Version",
+      "type": "string"
+    },
+    "primary_denominator": {
+      "$ref": "#/$defs/OffTargetDenominator"
+    },
+    "product_case_ref": {
+      "title": "Product Case Ref",
+      "type": "string"
+    },
+    "product_case_sha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Product Case Sha256",
+      "type": "string"
+    },
+    "product_definition_ref": {
+      "title": "Product Definition Ref",
+      "type": "string"
+    },
+    "product_definition_sha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "Product Definition Sha256",
+      "type": "string"
+    },
+    "profile_id": {
+      "pattern": "^off-target-control:[A-Za-z0-9._:-]+$",
+      "title": "Profile Id",
+      "type": "string"
+    },
+    "profile_version": {
+      "const": "0.2.0",
+      "title": "Profile Version",
+      "type": "string"
+    },
+    "rare_state_profile": {
+      "items": {
+        "$ref": "#/$defs/RareStateRecord"
+      },
+      "title": "Rare State Profile",
+      "type": "array"
+    },
+    "reason_codes": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Reason Codes",
+      "type": "array"
+    },
+    "role_composition": {
+      "items": {
+        "$ref": "#/$defs/RoleCompositionRecord"
+      },
+      "title": "Role Composition",
+      "type": "array"
+    },
+    "score_state": {
+      "const": "unavailable",
+      "title": "Score State",
+      "type": "string"
+    },
+    "state_role_map_ref": {
+      "title": "State Role Map Ref",
+      "type": "string"
+    },
+    "state_role_map_sha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "title": "State Role Map Sha256",
+      "type": "string"
+    },
+    "tool_id": {
+      "const": "P0-05",
+      "title": "Tool Id",
+      "type": "string"
+    },
+    "tool_version": {
+      "title": "Tool Version",
+      "type": "string"
+    },
+    "unknown_profile": {
+      "$ref": "#/$defs/UnknownProfile"
+    }
+  },
+  "required": [
+    "object_version",
+    "profile_id",
+    "profile_version",
+    "tool_id",
+    "tool_version",
+    "product_case_ref",
+    "product_case_sha256",
+    "product_definition_ref",
+    "product_definition_sha256",
+    "state_role_map_ref",
+    "state_role_map_sha256",
+    "assessment_spec_ref",
+    "assessment_spec_sha256",
+    "cell_state_profile_id",
+    "cell_state_profile_sha256",
+    "evidence_bundle_ref",
+    "evidence_bundle_sha256",
+    "primary_denominator",
+    "role_composition",
+    "unknown_profile",
+    "rare_state_profile",
+    "evidence_state",
+    "score_state",
+    "reason_codes",
+    "created_at",
+    "measurement_projection_state",
+    "measurement_artifacts"
+  ],
+  "title": "OffTargetControlProfileV2",
+  "type": "object"
+}

--- a/src/bridge/tool_packages/_input_contracts.py
+++ b/src/bridge/tool_packages/_input_contracts.py
@@ -472,6 +472,13 @@ INPUT_CONTRACTS: dict[str, ToolInputContract] = {
                     1,
                     1,
                 ),
+                _role(
+                    "measurement_spec",
+                    "bridge://schemas/measurement-spec/v0.2",
+                    None,
+                    0,
+                    1,
+                ),
             ),
             _mode(
                 "method_runtime",
@@ -505,6 +512,13 @@ INPUT_CONTRACTS: dict[str, ToolInputContract] = {
                     "bridge://schemas/off-target-evidence-bundle/v0.1",
                     V01,
                     1,
+                    1,
+                ),
+                _role(
+                    "measurement_spec",
+                    "bridge://schemas/measurement-spec/v0.2",
+                    None,
+                    0,
                     1,
                 ),
                 _role(

--- a/src/bridge/tool_packages/cards/P0-05.md
+++ b/src/bridge/tool_packages/cards/P0-05.md
@@ -5,21 +5,24 @@
 Account for a declared primary denominator under externally supplied roles and
 uncertainty rules. The package keeps its original aggregation interface and an explicit
 method-runtime interface for descriptive intervals, independent-unit bootstrap,
-rare-state spike-in/design calculations and multi-source OOD coordination.
+rare-state spike-in/design calculations and multi-source OOD coordination, plus
+an opt-in normalized measurement projection.
 
 ## Contract
 
 | Field | Value |
 |---|---|
-| Package version | `0.4.0` |
+| Package version | `0.5.0` |
 | Runtime state | `implemented` |
 | Scientific state | `candidate` |
 | Optional | `no` |
 | EnvironmentSpec | `ENV-P0-CORE-v0.1` (`health_check_passed`) |
 | Input envelope | `bridge://schemas/tool-request/v0.2` |
 | Output envelope | `bridge://schemas/tool-run/v0.2` |
-| Result schema | `bridge://schemas/off-target-control-profile/v0.1` |
+| Result schema | `bridge://schemas/off-target-control-profile/v0.2` |
 | Adapter | `bridge.tool_packages.p0_05_off_target_control.adapter:adapter` |
+
+Profile v0.1 remains packaged for legacy loading.
 
 Use `ToolRequestV2` through the Python SDK `validate_request` and `run_tool`,
 or the existing CLI:
@@ -49,6 +52,7 @@ P0-02 V3 profile so analysis units and reconciliation counts remain auditable.
 | `biological_unit_manifest` | method | `bridge://schemas/biological-unit-manifest/v0.1` | reviewed analysis-unit and independence-group mapping |
 | `off_target_method_spec` | method | `bridge://schemas/off-target-method-spec/v0.1` | selected methods, confidence level, bootstrap size, planning targets, OOD channel lineage and ordered rules |
 | `off_target_method_input` | method | `bridge://schemas/off-target-method-input/v0.1` | unit-level soft/hard composition, spike-in trials and OOD channel states |
+| `measurement_spec` | optional in both | `bridge://schemas/measurement-spec/v0.2` | exact ProductCase binding, `P0-05` tool authorization and all three allowed projection metric names |
 
 Every object is bound by Schema URI, object version, absolute regular-file path
 and SHA-256. Method mode also checks the exact ProductCase, P0-02 V3 profile,
@@ -67,16 +71,26 @@ The method selector currently executes:
 - `OOD-DISAGREE`: disagreement across distinct source families;
 - `OOD-ENSEMBLE`: ordered coordination rules supplied in the method spec.
 
-P0-05 refuses expression assets, arbitrary parameters, top-level
-MeasurementSpecs, V1 requests, unmapped states, undeclared unknown reasons,
-inactive specs, partial method inputs and any lineage/checksum mismatch.
+P0-05 refuses expression assets, arbitrary parameters, the legacy top-level
+`measurement_spec_ref`, V1 requests, unmapped states, undeclared unknown reasons,
+inactive specs, partial method inputs and any lineage/checksum mismatch. A structured
+MeasurementSpec fails closed unless `tool_refs` contains `P0-05` and
+`raw_metric_definition.metric_names` names exactly the three supported projections.
 
 ## Deterministic output
 
 Every successful run writes `off_target_control_profile.json` and returns the
 same object in `ToolRunV2.result`. Method mode atomically adds a checksummed
 `off_target_method_bundle.json` governed by
-`bridge://schemas/off-target-method-bundle/v0.1`. The primary profile contains:
+`bridge://schemas/off-target-method-bundle/v0.1`.
+
+P0-05 v0.5 always returns profile v0.2. Without a structured MeasurementSpec it
+preserves all domain records, sets `measurement_projection_state=not_requested`
+and binds no measurements. With an authorized MeasurementSpec it sets the state
+to `available` and atomically adds one checksummed `MeasurementResultV2` artifact
+per source record.
+
+The primary profile contains:
 
 - exact upstream refs and hashes and one primary denominator;
 - soft mass, observed count and fraction for the four generic product roles;
@@ -112,7 +126,19 @@ A calibrated zero rare-state observation may return
 `not_detected_above_lod` with its supplied upper bound, while missing or
 insufficient calibration returns `cannot_exclude` or `not_assessed`.
 
-The package emits no MeasurementResult and does not rerun single-cell analysis.
+Projection preserves the complete source records in profile v0.2 and uses this
+explicit evidence-state mapping:
+
+- role `available` to `inferred`, and `not_assessed` to `unavailable`;
+- unknown coverage `complete` or `partial` to `unknown(identity)`, and
+  `not_assessed` to `unavailable`;
+- rare `detected` to `inferred`, `not_detected_above_lod` to `negative`,
+  `cannot_exclude` to `unknown(measurement)`, and `not_assessed` to `unavailable`.
+
+States for which MeasurementResultV2 forbids values carry nulls, never fabricated
+zeros. Every projected result keeps `domain_score=null` and
+`score_state=unavailable`; no projection adds a threshold or safety interpretation.
+The package does not rerun single-cell analysis.
 Figures remain candidate explanations of the structured records.
 
 ## Biology and release boundary
@@ -136,7 +162,7 @@ analysis-unit and independence-group bindings, count and bootstrap intervals,
 hard/soft sensitivity, independent-group spike-in calibration, single-state
 binomial planning, checksummed OOD coordination,
 missing/zero semantics, checksum drift, deterministic reuse and output
-tampering.
+tampering, v0.1 compatibility and opt-in v0.2 measurement projection.
 
 Stable evidence:
 `docs/validation/p0_05_real_method_runtime_v0.3.md`.

--- a/src/bridge/tool_packages/p0_05_off_target_control/README.md
+++ b/src/bridge/tool_packages/p0_05_off_target_control/README.md
@@ -6,14 +6,25 @@ off-target method execution.
 ## Interface at a glance
 
 - **Input:** six checksummed JSON objects for compatible aggregation, or nine for
-  method execution with P0-02 V3 and reviewed biological-unit lineage.
+  method execution with P0-02 V3 and reviewed biological-unit lineage. Either mode
+  may add one authorized checksummed `MeasurementSpecV2` structured object.
 - **Output:** `OffTargetControlProfile`; method mode adds an
   `OffTargetMethodBundle` with intervals, sensitivity, spike-in/design and OOD
   coordination records. Both modes add typed visualization data, exact tables
   and static vector/raster figures for product-role accounting, rare-state
-  detectability and supplied OOD channel states.
+  detectability and supplied OOD channel states. P0-05 v0.5 always returns profile
+  v0.2. Without a MeasurementSpec its projection state is `not_requested`, its
+  spec binding is null and no normalized measurements are fabricated. With an
+  authorized MeasurementSpec the projection state is `available` and the profile
+  binds checksummed `MeasurementResultV2` artifacts for every role, the
+  identity-unknown profile and every configured rare state. Profile v0.1 remains
+  packaged only for legacy loading.
 - **Boundary:** “control” means composition accounting. It is not physical
   removal, a safety conclusion, a release decision or a domain score.
+
+Projection keeps the original domain records in profile v0.2. Missing,
+unavailable and measurement-unknown values remain null where required by the
+shared contract; zero observations are not interpreted as absence.
 
 ## Documentation
 

--- a/src/bridge/tool_packages/p0_05_off_target_control/adapter.py
+++ b/src/bridge/tool_packages/p0_05_off_target_control/adapter.py
@@ -18,9 +18,15 @@ from bridge.tool_packages._structured_runtime import (
     directory_state,
     failed_v2_run,
     load_structured_inputs,
+    objects_for_role,
     publish_json_bundle,
     request_v2_from_v1,
     single_object,
+)
+from bridge.tool_packages.p0_05_off_target_control.executor import (
+    MEASUREMENT_PROJECTION_METRIC_NAMES,
+    profile_v2_without_projection,
+    project_off_target_measurements,
 )
 from bridge.tool_packages.p0_05_off_target_control.method_binding import (
     method_binding_reasons,
@@ -61,6 +67,7 @@ from bridge.toolkit.contracts import (
     ExecutionState,
     FrozenModel,
     ImplementationState,
+    MeasurementSpecV2,
     StructuredInputRef,
     ToolPackageSpecV2,
     ToolRequest,
@@ -68,8 +75,9 @@ from bridge.toolkit.contracts import (
     ToolRunV2,
 )
 
-RESULT_SCHEMA_REF = "bridge://schemas/off-target-control-profile/v0.1"
-ROLE_CONTRACTS: dict[str, tuple[str, str, type[FrozenModel]]] = {
+RESULT_SCHEMA_REF_V2 = "bridge://schemas/off-target-control-profile/v0.2"
+MEASUREMENT_SPEC_ROLE = "measurement_spec"
+ROLE_CONTRACTS: dict[str, tuple[str, str | None, type[FrozenModel]]] = {
     "product_case": (
         "bridge://schemas/product-case/v0.1",
         "0.1.0",
@@ -100,6 +108,11 @@ ROLE_CONTRACTS: dict[str, tuple[str, str, type[FrozenModel]]] = {
         "0.1.0",
         OffTargetEvidenceBundle,
     ),
+    "measurement_spec": (
+        "bridge://schemas/measurement-spec/v0.2",
+        None,
+        MeasurementSpecV2,
+    ),
     "biological_unit_manifest": (
         "bridge://schemas/biological-unit-manifest/v0.1",
         "0.1.0",
@@ -123,6 +136,7 @@ METHOD_ROLES = frozenset(
         "off_target_method_input",
     }
 )
+BASE_ROLES = frozenset(set(ROLE_CONTRACTS) - METHOD_ROLES - {MEASUREMENT_SPEC_ROLE})
 CELL_STATE_V3_CONTRACT = (
     "bridge://schemas/cell-state-evidence-profile/v0.3",
     "0.3.0",
@@ -196,10 +210,14 @@ class OffTargetControlAdapter:
             "off_target_evidence_bundle",
             OffTargetEvidenceBundle,
         )
+        measurement_specs = objects_for_role(
+            request, loaded, MEASUREMENT_SPEC_ROLE, MeasurementSpecV2
+        )
+        measurement_spec = measurement_specs[0] if measurement_specs else None
 
         input_hash = _input_hash(request, spec)
         run_id = f"run-{input_hash[:16]}"
-        result = _aggregate_profile(
+        base_result = _aggregate_profile(
             request=request,
             spec=spec,
             input_hash=input_hash,
@@ -210,8 +228,35 @@ class OffTargetControlAdapter:
             cell_state_profile=cell_state_profile,
             evidence_bundle=evidence_bundle,
         )
+        evidence_ids = sorted(set(cell_state_profile.evidence_ids))
+        projection = None
+        result = base_result
+        measurements = []
+        measurement_payloads: dict[str, bytes] = {}
+        if measurement_spec is not None:
+            measurement_ref = next(
+                ref
+                for ref in request.object_inputs
+                if ref.role == MEASUREMENT_SPEC_ROLE
+            )
+            projection = project_off_target_measurements(
+                run_id=run_id,
+                tool_version=spec.version,
+                profile=base_result,
+                measurement_spec=measurement_spec,
+                measurement_spec_sha256=measurement_ref.sha256,
+                evidence_refs=evidence_ids,
+            )
+            result = projection.profile
+            measurements = projection.measurements
+            measurement_payloads = projection.payloads
+        elif spec.result_schema_ref == RESULT_SCHEMA_REF_V2:
+            result = profile_v2_without_projection(base_result)
         result_bytes = canonical_json_bytes(result.model_dump(mode="json"), indent=2)
-        payloads = {"off_target_control_profile.json": result_bytes}
+        payloads = {
+            "off_target_control_profile.json": result_bytes,
+            **measurement_payloads,
+        }
         method_spec = None
         method_input = None
         method_bundle = None
@@ -299,7 +344,6 @@ class OffTargetControlAdapter:
                 [exc.reason_code],
                 input_hash=input_hash,
             )
-        evidence_ids = sorted(set(cell_state_profile.evidence_ids))
         artifacts = [
             ArtifactManifest(
                 artifact_id=f"artifact:{run_id}:off-target-control",
@@ -310,6 +354,18 @@ class OffTargetControlAdapter:
                 evidence_ids=evidence_ids,
             )
         ]
+        if projection is not None:
+            for binding in projection.profile.measurement_artifacts:
+                artifacts.append(
+                    ArtifactManifest(
+                        artifact_id=binding.artifact_id,
+                        kind="measurement_result_v2",
+                        path=published[binding.file_name],
+                        media_type="application/json",
+                        sha256=binding.sha256,
+                        evidence_ids=evidence_ids,
+                    )
+                )
         if method_bytes is not None:
             artifacts.append(
                 ArtifactManifest(
@@ -331,10 +387,10 @@ class OffTargetControlAdapter:
             environment_spec_id=spec.environment_spec_id,
             input_hash=input_hash,
             created_at=evidence_bundle.created_at,
-            measurements=[],
+            measurements=measurements,
             artifacts=artifacts,
             visualizations=[],
-            result_schema_ref=RESULT_SCHEMA_REF,
+            result_schema_ref=spec.result_schema_ref,
             result=result.model_dump(mode="json"),
             reason_codes=[],
             warnings=[],
@@ -369,8 +425,14 @@ def _envelope_reasons(request: ToolRequestV2, spec: ToolPackageSpecV2) -> list[s
     if request.parameters:
         reasons.append("p0_05_parameters_forbidden")
     roles = [ref.role for ref in request.object_inputs]
-    base_roles = set(ROLE_CONTRACTS) - METHOD_ROLES
-    for role in base_roles:
+    measurement_spec_count = roles.count(MEASUREMENT_SPEC_ROLE)
+    if measurement_spec_count > 1:
+        reasons.append("at_most_one_measurement_spec_allowed")
+    if (
+        measurement_spec_count == 1 and spec.result_schema_ref != RESULT_SCHEMA_REF_V2
+    ):
+        reasons.append("measurement_projection_requires_profile_v2")
+    for role in BASE_ROLES:
         if roles.count(role) != 1:
             reasons.append(f"exactly_one_{role}_required")
     method_mode = _uses_method_runtime(request.object_inputs)
@@ -381,6 +443,10 @@ def _envelope_reasons(request: ToolRequestV2, spec: ToolPackageSpecV2) -> list[s
     if any(role not in ROLE_CONTRACTS for role in roles):
         reasons.append("unsupported_object_input_role")
     for ref in request.object_inputs:
+        if ref.role == MEASUREMENT_SPEC_ROLE:
+            if ref.schema_ref != ROLE_CONTRACTS[MEASUREMENT_SPEC_ROLE][0]:
+                reasons.append("object_input_schema_mismatch")
+            continue
         contract = ROLE_CONTRACTS.get(ref.role)
         if contract is None:
             continue
@@ -414,7 +480,10 @@ def _load_inputs(
 
 
 def _validate_object_version(ref: StructuredInputRef, value: FrozenModel) -> None:
-    if ref.role == "cell_state_evidence_profile":
+    if ref.role == MEASUREMENT_SPEC_ROLE:
+        expected = value.version
+        actual = ref.object_version
+    elif ref.role == "cell_state_evidence_profile":
         if isinstance(value, CellStateEvidenceProfileV3):
             expected = CELL_STATE_V3_CONTRACT[1]
         else:
@@ -455,6 +524,10 @@ def _binding_reasons(request: ToolRequestV2, loaded: LoadedInputs) -> list[str]:
         "off_target_evidence_bundle",
         OffTargetEvidenceBundle,
     )
+    measurement_specs = objects_for_role(
+        request, loaded, MEASUREMENT_SPEC_ROLE, MeasurementSpecV2
+    )
+    measurement_spec = measurement_specs[0] if measurement_specs else None
     input_refs = {ref.role: ref for ref in request.object_inputs}
     reasons: list[str] = []
 
@@ -484,6 +557,40 @@ def _binding_reasons(request: ToolRequestV2, loaded: LoadedInputs) -> list[str]:
         != product_case.measurement_spec_ref.object_version
     ):
         reasons.append("cell_state_measurement_spec_binding_mismatch")
+
+    if measurement_spec is not None:
+        if (
+            measurement_spec.measurement_spec_id
+            != product_case.measurement_spec_ref.object_id
+            or measurement_spec.version
+            != product_case.measurement_spec_ref.object_version
+        ):
+            reasons.append("measurement_spec_product_case_binding_mismatch")
+        if measurement_spec.assay != product_case.assay:
+            reasons.append("measurement_spec_assay_mismatch")
+        if (
+            measurement_spec.applicable_product_cards
+            and product_definition.product_definition_id
+            not in measurement_spec.applicable_product_cards
+            and product_definition.ref.ref
+            not in measurement_spec.applicable_product_cards
+        ):
+            reasons.append("measurement_spec_product_definition_not_applicable")
+        if "P0-05" not in measurement_spec.tool_refs:
+            reasons.append("measurement_spec_tool_not_authorized")
+        metric_names = measurement_spec.raw_metric_definition.get("metric_names")
+        if (
+            not isinstance(metric_names, list)
+            or not all(isinstance(item, str) for item in metric_names)
+            or len(metric_names) != len(set(metric_names))
+            or set(metric_names) != MEASUREMENT_PROJECTION_METRIC_NAMES
+        ):
+            reasons.append("measurement_spec_metric_names_mismatch")
+        if isinstance(cell_state_profile, CellStateEvidenceProfileV3) and (
+            cell_state_profile.measurement_spec_sha256
+            != input_refs[MEASUREMENT_SPEC_ROLE].sha256
+        ):
+            reasons.append("measurement_spec_checksum_mismatch")
 
     if not assessment_spec.active:
         reasons.append("off_target_assessment_spec_inactive")
@@ -823,7 +930,7 @@ def _failed_run(
         request,
         spec,
         reasons,
-        result_schema_ref=RESULT_SCHEMA_REF,
+        result_schema_ref=spec.result_schema_ref,
         fingerprint_input_key="structured_inputs",
         input_hash=input_hash,
     )

--- a/src/bridge/tool_packages/p0_05_off_target_control/executor.py
+++ b/src/bridge/tool_packages/p0_05_off_target_control/executor.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Literal
+
+from bridge.tool_packages._configurable_contracts import VersionedObjectRef
+from bridge.tool_packages._structured_runtime import canonical_json_bytes
+from bridge.tool_packages.p0_05_off_target_control.models import (
+    CoverageState,
+    OffTargetControlProfile,
+    OffTargetControlProfileV2,
+    OffTargetMeasurementArtifactBinding,
+    RareDetectionState,
+    rare_projection_evidence_state,
+    role_projection_evidence_state,
+    unknown_projection_evidence_state,
+)
+from bridge.toolkit.contracts import (
+    EvidenceState,
+    MeasurementResultV2,
+    MeasurementSpecV2,
+    ScoreState,
+)
+
+ROLE_METRIC_NAME = "off_target_role_composition"
+UNKNOWN_METRIC_NAME = "off_target_identity_unknown"
+RARE_METRIC_NAME = "off_target_rare_state_detection"
+MEASUREMENT_PROJECTION_METRIC_NAMES = frozenset(
+    {ROLE_METRIC_NAME, UNKNOWN_METRIC_NAME, RARE_METRIC_NAME}
+)
+
+
+@dataclass(frozen=True)
+class MeasurementProjectionBundle:
+    profile: OffTargetControlProfileV2
+    measurements: list[MeasurementResultV2]
+    payloads: dict[str, bytes]
+
+
+@dataclass(frozen=True)
+class _ProjectionDraft:
+    metric_name: Literal[
+        "off_target_role_composition",
+        "off_target_identity_unknown",
+        "off_target_rare_state_detection",
+    ]
+    record_scope: Literal["role", "identity_unknown", "rare_state"]
+    record_id: str
+    raw_record: dict
+    evidence_state: EvidenceState
+    unknown_scope: Literal["identity", "measurement"] | None = None
+
+
+def profile_v2_without_projection(
+    profile: OffTargetControlProfile,
+) -> OffTargetControlProfileV2:
+    return OffTargetControlProfileV2.model_validate(
+        {
+            **profile.model_dump(mode="python"),
+            "object_version": "0.2.0",
+            "profile_version": "0.2.0",
+            "measurement_projection_state": "not_requested",
+            "measurement_spec_ref": None,
+            "measurement_spec_sha256": None,
+            "measurement_artifacts": [],
+        }
+    )
+
+
+def project_off_target_measurements(
+    *,
+    run_id: str,
+    tool_version: str,
+    profile: OffTargetControlProfile,
+    measurement_spec: MeasurementSpecV2,
+    measurement_spec_sha256: str,
+    evidence_refs: list[str],
+) -> MeasurementProjectionBundle:
+    drafts = _projection_drafts(profile)
+    measurements: list[MeasurementResultV2] = []
+    payloads: dict[str, bytes] = {}
+    bindings: list[OffTargetMeasurementArtifactBinding] = []
+    for draft in drafts:
+        token = _record_token(draft.record_scope, draft.record_id)
+        measurement = _measurement(
+            run_id=run_id,
+            tool_version=tool_version,
+            measurement_spec=measurement_spec,
+            draft=draft,
+            token=token,
+            evidence_refs=evidence_refs,
+        )
+        payload = canonical_json_bytes(measurement.model_dump(mode="json"), indent=2)
+        filename = f"{token}.{draft.metric_name}.measurement_result.json"
+        artifact_id = f"artifact:{run_id}:{token}:{draft.metric_name}"
+        sha256 = hashlib.sha256(payload).hexdigest()
+        measurements.append(measurement)
+        payloads[filename] = payload
+        bindings.append(
+            OffTargetMeasurementArtifactBinding(
+                measurement_id=measurement.measurement_id,
+                metric_name=draft.metric_name,
+                record_scope=draft.record_scope,
+                record_id=draft.record_id,
+                evidence_state=draft.evidence_state,
+                artifact_id=artifact_id,
+                file_name=filename,
+                sha256=sha256,
+            )
+        )
+
+    profile_v2 = OffTargetControlProfileV2.model_validate(
+        {
+            **profile.model_dump(mode="python"),
+            "object_version": "0.2.0",
+            "profile_version": "0.2.0",
+            "measurement_projection_state": "available",
+            "measurement_spec_ref": VersionedObjectRef(
+                object_id=measurement_spec.measurement_spec_id,
+                object_version=measurement_spec.version,
+            ),
+            "measurement_spec_sha256": measurement_spec_sha256,
+            "measurement_artifacts": sorted(
+                bindings, key=lambda item: item.file_name
+            ),
+        }
+    )
+    return MeasurementProjectionBundle(
+        profile=profile_v2,
+        measurements=measurements,
+        payloads=payloads,
+    )
+
+
+def _projection_drafts(profile: OffTargetControlProfile) -> list[_ProjectionDraft]:
+    drafts = [
+        _ProjectionDraft(
+            metric_name=ROLE_METRIC_NAME,
+            record_scope="role",
+            record_id=record.product_role.value,
+            raw_record=record.model_dump(mode="json"),
+            evidence_state=role_projection_evidence_state(record.assessment_state),
+        )
+        for record in profile.role_composition
+    ]
+    drafts.append(
+        _ProjectionDraft(
+            metric_name=UNKNOWN_METRIC_NAME,
+            record_scope="identity_unknown",
+            record_id="identity-unknown",
+            raw_record=profile.unknown_profile.model_dump(mode="json"),
+            evidence_state=unknown_projection_evidence_state(
+                profile.unknown_profile.coverage_state
+            ),
+            unknown_scope=(
+                "identity"
+                if profile.unknown_profile.coverage_state
+                is not CoverageState.NOT_ASSESSED
+                else None
+            ),
+        )
+    )
+    drafts.extend(
+        _ProjectionDraft(
+            metric_name=RARE_METRIC_NAME,
+            record_scope="rare_state",
+            record_id=record.state_id,
+            raw_record=record.model_dump(mode="json"),
+            evidence_state=rare_projection_evidence_state(record.detection_state),
+            unknown_scope=(
+                "measurement"
+                if record.detection_state is RareDetectionState.CANNOT_EXCLUDE
+                else None
+            ),
+        )
+        for record in profile.rare_state_profile
+    )
+    return sorted(
+        drafts,
+        key=lambda item: (item.record_scope, item.record_id, item.metric_name),
+    )
+
+
+def _measurement(
+    *,
+    run_id: str,
+    tool_version: str,
+    measurement_spec: MeasurementSpecV2,
+    draft: _ProjectionDraft,
+    token: str,
+    evidence_refs: list[str],
+) -> MeasurementResultV2:
+    raw_value = (
+        None
+        if draft.evidence_state is EvidenceState.UNAVAILABLE
+        or (
+            draft.evidence_state is EvidenceState.UNKNOWN
+            and draft.unknown_scope == "measurement"
+        )
+        else draft.raw_record
+    )
+    run_token = run_id.removeprefix("run-")
+    return MeasurementResultV2(
+        measurement_id=f"measurement:{run_token}:{token}:{draft.metric_name}",
+        measurement_spec_id=measurement_spec.measurement_spec_id,
+        measurement_spec_version=measurement_spec.version,
+        metric_name=draft.metric_name,
+        raw_value=raw_value,
+        unit=None,
+        numerator=None,
+        denominator=None,
+        interval=None,
+        interval_confidence_level=None,
+        interval_method_ref=None,
+        source_run_ref=f"tool-run:{run_id}@{tool_version}",
+        source_execution_state="succeeded",
+        unknown_scope=draft.unknown_scope,
+        domain_score=None,
+        score_state=ScoreState.UNAVAILABLE,
+        evidence_state=draft.evidence_state,
+        provenance_refs=evidence_refs,
+    )
+
+
+def _record_token(record_scope: str, record_id: str) -> str:
+    digest = hashlib.sha256(
+        canonical_json_bytes([record_scope, record_id])
+    ).hexdigest()[:12]
+    scope_token = record_scope.replace("_", "-")
+    return f"p005-{scope_token}-{digest}"

--- a/src/bridge/tool_packages/p0_05_off_target_control/models.py
+++ b/src/bridge/tool_packages/p0_05_off_target_control/models.py
@@ -5,7 +5,14 @@ from datetime import datetime, timezone
 from enum import StrEnum
 from typing import Literal, Self
 
-from pydantic import Field, StrictFloat, StrictInt, field_validator, model_validator
+from pydantic import (
+    ConfigDict,
+    Field,
+    StrictFloat,
+    StrictInt,
+    field_validator,
+    model_validator,
+)
 
 from bridge.tool_packages._configurable_contracts import (
     ProductRole,
@@ -15,7 +22,7 @@ from bridge.tool_packages._configurable_contracts import (
 from bridge.tool_packages.p0_05_off_target_control.method_models import (
     PUBLIC_METHOD_SCHEMA_MODELS,
 )
-from bridge.toolkit.contracts import FrozenModel
+from bridge.toolkit.contracts import EvidenceState, FrozenModel
 
 OBJECT_ID_PATTERN = r"^[A-Za-z][A-Za-z0-9._:-]*$"
 VERSION_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._:-]*$"
@@ -57,6 +64,28 @@ class RareDetectionState(StrEnum):
     NOT_ASSESSED = "not_assessed"
 
 
+def role_projection_evidence_state(state: AssessmentState) -> EvidenceState:
+    return {
+        AssessmentState.AVAILABLE: EvidenceState.INFERRED,
+        AssessmentState.NOT_ASSESSED: EvidenceState.UNAVAILABLE,
+    }[state]
+
+
+def unknown_projection_evidence_state(state: CoverageState) -> EvidenceState:
+    return {
+        CoverageState.COMPLETE: EvidenceState.UNKNOWN,
+        CoverageState.PARTIAL: EvidenceState.UNKNOWN,
+        CoverageState.NOT_ASSESSED: EvidenceState.UNAVAILABLE,
+    }[state]
+
+
+def rare_projection_evidence_state(state: RareDetectionState) -> EvidenceState:
+    return {
+        RareDetectionState.DETECTED: EvidenceState.INFERRED,
+        RareDetectionState.NOT_DETECTED_ABOVE_LOD: EvidenceState.NEGATIVE,
+        RareDetectionState.CANNOT_EXCLUDE: EvidenceState.UNKNOWN,
+        RareDetectionState.NOT_ASSESSED: EvidenceState.UNAVAILABLE,
+    }[state]
 
 
 class RareStateRule(FrozenModel):
@@ -249,6 +278,21 @@ class RareStateRecord(FrozenModel):
     reason_codes: list[str]
 
 
+class OffTargetMeasurementArtifactBinding(FrozenModel):
+    measurement_id: str = Field(min_length=1)
+    metric_name: Literal[
+        "off_target_role_composition",
+        "off_target_identity_unknown",
+        "off_target_rare_state_detection",
+    ]
+    record_scope: Literal["role", "identity_unknown", "rare_state"]
+    record_id: str = Field(pattern=OBJECT_ID_PATTERN)
+    evidence_state: EvidenceState
+    artifact_id: str = Field(min_length=1)
+    file_name: str = Field(pattern=r"^[a-z0-9][a-z0-9_.-]*\.json$")
+    sha256: str = Field(pattern=SHA256_PATTERN)
+
+
 class OffTargetControlProfile(FrozenModel):
     object_version: Literal["0.1.0"]
     profile_id: str = Field(pattern=r"^off-target-control:[A-Za-z0-9._:-]+$")
@@ -280,10 +324,151 @@ class OffTargetControlProfile(FrozenModel):
     _created_at_utc = field_validator("created_at")(_aware_utc)
 
 
+class OffTargetControlProfileV2(OffTargetControlProfile):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "measurement_projection_state": {
+                                "const": "not_requested"
+                            }
+                        },
+                        "required": ["measurement_projection_state"],
+                    },
+                    "then": {
+                        "required": [
+                            "measurement_artifacts",
+                        ],
+                        "properties": {
+                            "measurement_spec_ref": {"type": "null"},
+                            "measurement_spec_sha256": {"type": "null"},
+                            "measurement_artifacts": {"maxItems": 0},
+                        },
+                    },
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "measurement_projection_state": {"const": "available"}
+                        },
+                        "required": ["measurement_projection_state"],
+                    },
+                    "then": {
+                        "required": [
+                            "measurement_spec_ref",
+                            "measurement_spec_sha256",
+                            "measurement_artifacts",
+                        ],
+                        "properties": {
+                            "measurement_spec_ref": {"not": {"type": "null"}},
+                            "measurement_spec_sha256": {
+                                "not": {"type": "null"}
+                            },
+                            "measurement_artifacts": {"minItems": 1},
+                        },
+                    },
+                },
+            ]
+        }
+    )
+
+    object_version: Literal["0.2.0"]
+    profile_version: Literal["0.2.0"]
+    measurement_projection_state: Literal["not_requested", "available"]
+    measurement_spec_ref: VersionedObjectRef | None = None
+    measurement_spec_sha256: str | None = Field(
+        default=None, pattern=SHA256_PATTERN
+    )
+    measurement_artifacts: list[OffTargetMeasurementArtifactBinding]
+
+    @model_validator(mode="after")
+    def measurement_projection_is_coherent(self) -> Self:
+        measurement_ids = [item.measurement_id for item in self.measurement_artifacts]
+        artifact_ids = [item.artifact_id for item in self.measurement_artifacts]
+        file_names = [item.file_name for item in self.measurement_artifacts]
+        binding_keys = [
+            (item.record_scope, item.record_id)
+            for item in self.measurement_artifacts
+        ]
+        for values, name in (
+            (measurement_ids, "measurement IDs"),
+            (artifact_ids, "measurement artifact IDs"),
+            (file_names, "measurement artifact file names"),
+            (binding_keys, "projected source records"),
+        ):
+            if len(values) != len(set(values)):
+                raise ValueError(f"{name} must be unique")
+        if self.measurement_projection_state == "not_requested":
+            if (
+                self.measurement_spec_ref is not None
+                or self.measurement_spec_sha256 is not None
+                or self.measurement_artifacts
+            ):
+                raise ValueError(
+                    "not-requested projection cannot bind a spec or measurements"
+                )
+            return self
+        if (
+            self.measurement_spec_ref is None
+            or self.measurement_spec_sha256 is None
+        ):
+            raise ValueError("available projection requires a measurement spec")
+        expected = {
+            *(("role", item.product_role.value) for item in self.role_composition),
+            ("identity_unknown", "identity-unknown"),
+            *(("rare_state", item.state_id) for item in self.rare_state_profile),
+        }
+        if set(binding_keys) != expected:
+            raise ValueError(
+                "available projection must bind every role, unknown and rare record"
+            )
+        expected_metric_by_scope = {
+            "role": "off_target_role_composition",
+            "identity_unknown": "off_target_identity_unknown",
+            "rare_state": "off_target_rare_state_detection",
+        }
+        if any(
+            item.metric_name != expected_metric_by_scope[item.record_scope]
+            for item in self.measurement_artifacts
+        ):
+            raise ValueError("measurement metric must match its source record scope")
+        expected_evidence_by_record = {
+            **{
+                ("role", item.product_role.value): role_projection_evidence_state(
+                    item.assessment_state
+                )
+                for item in self.role_composition
+            },
+            ("identity_unknown", "identity-unknown"): unknown_projection_evidence_state(
+                self.unknown_profile.coverage_state
+            ),
+            **{
+                ("rare_state", item.state_id): rare_projection_evidence_state(
+                    item.detection_state
+                )
+                for item in self.rare_state_profile
+            },
+        }
+        if any(
+            item.evidence_state
+            is not expected_evidence_by_record[
+                (item.record_scope, item.record_id)
+            ]
+            for item in self.measurement_artifacts
+        ):
+            raise ValueError(
+                "measurement evidence must match its source record state"
+            )
+        return self
+
+
 PUBLIC_SCHEMA_MODELS = {
     "bridge://schemas/state-role-map/v0.1": StateRoleMap,
     "bridge://schemas/off-target-assessment-spec/v0.1": OffTargetAssessmentSpec,
     "bridge://schemas/off-target-evidence-bundle/v0.1": OffTargetEvidenceBundle,
     "bridge://schemas/off-target-control-profile/v0.1": OffTargetControlProfile,
+    "bridge://schemas/off-target-control-profile/v0.2": OffTargetControlProfileV2,
     **PUBLIC_METHOD_SCHEMA_MODELS,
 }

--- a/src/bridge/tool_packages/specs/p0_05.yaml
+++ b/src/bridge/tool_packages/specs/p0_05.yaml
@@ -1,6 +1,6 @@
 tool_id: P0-05
 name: Off-target Control
-version: 0.4.0
+version: 0.5.0
 summary: Account for declared product roles, rare-state detectability, and supplied OOD states with typed figures and exact tables.
 implementation_state: implemented
 scientific_status: candidate
@@ -19,4 +19,4 @@ method_ids:
   - METHOD-BRIDGE-OOD-ENSEMBLE
 card_ref: bridge://tool-cards/P0-05
 adapter_ref: bridge.tool_packages.p0_05_off_target_control.adapter:adapter
-result_schema_ref: bridge://schemas/off-target-control-profile/v0.1
+result_schema_ref: bridge://schemas/off-target-control-profile/v0.2

--- a/src/bridge/toolkit/schemas.py
+++ b/src/bridge/toolkit/schemas.py
@@ -89,6 +89,7 @@ SCHEMA_REFS = {
     "bridge://schemas/measurement-spec/v0.2": "measurement_spec_v2.schema.json",
     "bridge://schemas/off-target-assessment-spec/v0.1": "off_target_assessment_spec.schema.json",
     "bridge://schemas/off-target-control-profile/v0.1": "off_target_control_profile.schema.json",
+    "bridge://schemas/off-target-control-profile/v0.2": "off_target_control_profile_v2.schema.json",
     "bridge://schemas/off-target-control-visualization-data/v0.1": "off_target_control_visualization_data.schema.json",
     "bridge://schemas/off-target-evidence-bundle/v0.1": "off_target_evidence_bundle.schema.json",
     "bridge://schemas/off-target-method-bundle/v0.1": "off_target_method_bundle.schema.json",

--- a/tests/test_p0_05_off_target_control.py
+++ b/tests/test_p0_05_off_target_control.py
@@ -6,9 +6,13 @@ import json
 from pathlib import Path
 from typing import Callable
 
+from jsonschema import Draft202012Validator
 import pytest
 
 from bridge.tool_packages.p0_05_off_target_control.adapter import adapter
+from bridge.tool_packages.p0_05_off_target_control.models import (
+    OffTargetControlProfileV2,
+)
 from bridge.tool_packages.p0_05_off_target_control.visualization_data import (
     OffTargetControlVisualizationDataV1,
     P005VisualizationArtifactSet,
@@ -16,7 +20,9 @@ from bridge.tool_packages.p0_05_off_target_control.visualization_data import (
 from bridge.toolkit.contracts import (
     ExecutionState,
     ImplementationState,
+    MeasurementResultV2,
     StructuredInputRef,
+    ToolPackageSpecV2,
     ToolRequest,
     ToolRequestV2,
 )
@@ -249,9 +255,88 @@ def _request(tmp_path: Path) -> ToolRequestV2:
     return ToolRequestV2(
         request_id="request-p0-05",
         tool_id="P0-05",
-        tool_version="0.4.0",
+        tool_version="0.5.0",
         output_dir=tmp_path / "output",
         object_inputs=refs,
+    )
+
+
+def _projection_spec() -> ToolPackageSpecV2:
+    return ToolRegistry.load_default().describe("P0-05")
+
+
+def _projection_request(request: ToolRequestV2) -> ToolRequestV2:
+    return request
+
+
+def _with_measurement_spec(request: ToolRequestV2) -> ToolRequestV2:
+    root = request.object_inputs[0].path.parent
+    payload = {
+        "measurement_spec_id": "measurement-spec:cell-state",
+        "version": "1",
+        "scientific_question": (
+            "How should declared off-target accounting records be projected?"
+        ),
+        "assay": "scRNA-seq",
+        "status": "candidate",
+        "applicable_product_cards": ["product-definition:demo@1"],
+        "input_contract": {
+            "source_result": "off-target-control-profile",
+            "projection": "record_preserving",
+        },
+        "analysis_unit": "preparation",
+        "analysis_unit_kind": "preparation",
+        "independence_group_kind": "sample",
+        "observation_unit_kind": "cell",
+        "applicable_contexts": ["in_vitro_product_assessment"],
+        "raw_metric_definition": {
+            "metric_names": [
+                "off_target_identity_unknown",
+                "off_target_rare_state_detection",
+                "off_target_role_composition",
+            ]
+        },
+        "numerator": None,
+        "denominator": None,
+        "direction": None,
+        "uncertainty_method": None,
+        "minimum_data": {},
+        "missing_behavior": "preserve_missing_unknown_and_unavailable_states",
+        "tool_refs": ["P0-05"],
+        "reference_refs": [],
+        "prior_refs": [],
+        "validation_ref": None,
+        "exclusion_rules": {},
+        "release_manifest_ref": None,
+    }
+    path = root / "measurement_spec.json"
+    digest = _write(path, payload)
+    ref = StructuredInputRef(
+        input_id="input-measurement-spec",
+        role="measurement_spec",
+        schema_ref="bridge://schemas/measurement-spec/v0.2",
+        object_version=payload["version"],
+        path=path,
+        sha256=digest,
+    )
+    return request.model_copy(
+        update={"object_inputs": [*request.object_inputs, ref]}
+    )
+
+
+def _projected_measurement(
+    run, record_scope: str, record_id: str
+) -> MeasurementResultV2:
+    binding = next(
+        item
+        for item in run.result["measurement_artifacts"]
+        if item["record_scope"] == record_scope and item["record_id"] == record_id
+    )
+    artifact = next(
+        item for item in run.artifacts if item.artifact_id == binding["artifact_id"]
+    )
+    return MeasurementResultV2.model_validate_json(
+        artifact.path.read_text(encoding="utf-8")
     )
 
 
@@ -281,9 +366,9 @@ def test_registry_exposes_executable_p0_05() -> None:
     spec = ToolRegistry.load_default().describe("P0-05")
 
     assert spec.implementation_state is ImplementationState.IMPLEMENTED
-    assert spec.version == "0.4.0"
+    assert spec.version == "0.5.0"
     assert spec.result_schema_ref == (
-        "bridge://schemas/off-target-control-profile/v0.1"
+        "bridge://schemas/off-target-control-profile/v0.2"
     )
     assert spec.method_ids == [
         "METHOD-BRIDGE-ROLE-AWARE-SOFT-COMPOSITION",
@@ -295,6 +380,15 @@ def test_registry_exposes_executable_p0_05() -> None:
         "METHOD-BRIDGE-MODEL-AND-REFERENCE-DISAGREEMENT",
         "METHOD-BRIDGE-OOD-ENSEMBLE",
     ]
+    contract = ToolRegistry.load_default().describe_input("P0-05")
+    for mode in contract.object_input_modes:
+        role = next(item for item in mode.roles if item.role == "measurement_spec")
+        assert role.schema_refs == ["bridge://schemas/measurement-spec/v0.2"]
+        assert role.object_version_policy == "payload"
+        assert role.min_count == 0
+        assert role.max_count == 1
+
+
 
 
 def test_happy_run_aggregates_external_roles_and_publishes_checksum(
@@ -308,6 +402,10 @@ def test_happy_run_aggregates_external_roles_and_publishes_checksum(
 
     assert run.execution_state is ExecutionState.SUCCEEDED
     assert run.measurements == []
+    assert run.result_schema_ref.endswith("off-target-control-profile/v0.2")
+    assert run.result["object_version"] == "0.2.0"
+    assert run.result["profile_version"] == "0.2.0"
+    assert run.result["measurement_projection_state"] == "not_requested"
     assert len(run.artifacts) == 15
     assert _role(run.result, "target")["fraction"] == pytest.approx(0.7)
     assert _role(run.result, "known_off_target")["fraction"] == pytest.approx(0.2)
@@ -356,6 +454,298 @@ def test_happy_run_aggregates_external_roles_and_publishes_checksum(
     assert load_schema(
         "bridge://schemas/p0-05-visualization-artifact-set/v0.1"
     )
+
+
+def test_v05_without_measurement_spec_uses_v2_not_requested_profile(
+    tmp_path: Path,
+) -> None:
+    request = _projection_request(_request(tmp_path))
+    run = adapter.run(request, _projection_spec())
+
+    assert run.execution_state is ExecutionState.SUCCEEDED
+    assert run.result_schema_ref == _projection_spec().result_schema_ref
+    assert run.result["object_version"] == "0.2.0"
+    assert run.result["profile_version"] == "0.2.0"
+    assert run.result["measurement_projection_state"] == "not_requested"
+    assert run.result["measurement_spec_ref"] is None
+    assert run.result["measurement_spec_sha256"] is None
+    assert run.result["measurement_artifacts"] == []
+    assert run.measurements == []
+    assert not any(
+        item.kind == "measurement_result_v2" for item in run.artifacts
+    )
+    assert _role(run.result, "target")["fraction"] == pytest.approx(0.7)
+    assert run.result["unknown_profile"]["fraction"] == pytest.approx(0.1)
+    assert run.result["rare_state_profile"][0]["detection_state"] == "detected"
+
+
+def test_v2_json_schema_encodes_projection_state_coherence(tmp_path: Path) -> None:
+    base_request = _request(tmp_path)
+    not_requested = adapter.run(
+        _projection_request(base_request),
+        _projection_spec(),
+    ).result
+    available = adapter.run(
+        _projection_request(_with_measurement_spec(base_request)),
+        _projection_spec(),
+    ).result
+    schema = OffTargetControlProfileV2.model_json_schema()
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+
+    assert not list(validator.iter_errors(not_requested))
+    assert not list(validator.iter_errors(available))
+
+    omitted_default_fields = json.loads(json.dumps(not_requested))
+    omitted_default_fields.pop("measurement_spec_ref")
+    omitted_default_fields.pop("measurement_spec_sha256")
+    parsed = OffTargetControlProfileV2.model_validate(omitted_default_fields)
+
+    assert parsed.measurement_spec_ref is None
+    assert parsed.measurement_spec_sha256 is None
+    assert not list(validator.iter_errors(omitted_default_fields))
+
+    invalid_not_requested = json.loads(json.dumps(not_requested))
+    invalid_not_requested.update(
+        {
+            "measurement_spec_ref": available["measurement_spec_ref"],
+            "measurement_spec_sha256": available["measurement_spec_sha256"],
+            "measurement_artifacts": available["measurement_artifacts"],
+        }
+    )
+    assert list(validator.iter_errors(invalid_not_requested))
+
+    invalid_available = json.loads(json.dumps(available))
+    invalid_available.update(
+        {
+            "measurement_spec_ref": None,
+            "measurement_spec_sha256": None,
+            "measurement_artifacts": [],
+        }
+    )
+    assert list(validator.iter_errors(invalid_available))
+
+
+def test_measurement_spec_opts_into_v02_checksummed_record_projection(
+    tmp_path: Path,
+) -> None:
+    request = _projection_request(_with_measurement_spec(_request(tmp_path)))
+
+    registry = ToolRegistry.load_default()
+    assert registry.check_eligibility(request).eligible
+    run = registry.run(request)
+
+    assert run.execution_state is ExecutionState.SUCCEEDED
+    assert run.result_schema_ref == _projection_spec().result_schema_ref
+    assert run.result["measurement_projection_state"] == "available"
+    assert run.result["object_version"] == "0.2.0"
+    assert run.result["profile_version"] == "0.2.0"
+    assert run.result["measurement_spec_ref"] == {
+        "object_id": "measurement-spec:cell-state",
+        "object_version": "1",
+    }
+    assert len(run.measurements) == 6
+    assert len(run.result["measurement_artifacts"]) == 6
+    assert len(run.artifacts) == 21
+    measurement_artifacts = [
+        item for item in run.artifacts if item.kind == "measurement_result_v2"
+    ]
+    assert len(measurement_artifacts) == 6
+    for artifact in measurement_artifacts:
+        assert hashlib.sha256(artifact.path.read_bytes()).hexdigest() == artifact.sha256
+        measurement = MeasurementResultV2.model_validate_json(
+            artifact.path.read_text(encoding="utf-8")
+        )
+        assert measurement.domain_score is None
+        assert measurement.measurement_spec_id == "measurement-spec:cell-state"
+        assert measurement.measurement_spec_version == "1"
+        assert measurement.source_execution_state == "succeeded"
+
+    target = _projected_measurement(run, "role", "target")
+    assert target.evidence_state.value == "inferred"
+    assert target.raw_value == _role(run.result, "target")
+    assert target.score_state.value == "unavailable"
+    unresolved = _projected_measurement(run, "role", "role_unresolved")
+    assert unresolved.evidence_state.value == "inferred"
+    assert unresolved.raw_value["observed_count"] == 0
+    assert unresolved.raw_value["exclusion_state"] == "cannot_exclude"
+    unknown = _projected_measurement(run, "identity_unknown", "identity-unknown")
+    assert unknown.evidence_state.value == "unknown"
+    assert unknown.unknown_scope == "identity"
+    assert unknown.raw_value == run.result["unknown_profile"]
+    assert unknown.score_state.value == "unavailable"
+    rare = _projected_measurement(run, "rare_state", "state:b")
+    assert rare.evidence_state.value == "inferred"
+    assert rare.raw_value == run.result["rare_state_profile"][0]
+    assert rare.score_state.value == "unavailable"
+
+
+def test_v2_profile_rejects_scope_metric_binding_tamper(tmp_path: Path) -> None:
+    run = adapter.run(
+        _projection_request(_with_measurement_spec(_request(tmp_path))),
+        _projection_spec(),
+    )
+    payload = run.result
+    target = next(
+        item
+        for item in payload["measurement_artifacts"]
+        if item["record_scope"] == "role" and item["record_id"] == "target"
+    )
+    target["metric_name"] = "off_target_rare_state_detection"
+
+    with pytest.raises(
+        ValueError,
+        match="measurement metric must match its source record scope",
+    ):
+        OffTargetControlProfileV2.model_validate(payload)
+
+
+def test_v2_profile_rejects_source_evidence_state_binding_tamper(
+    tmp_path: Path,
+) -> None:
+    run = adapter.run(
+        _projection_request(_with_measurement_spec(_request(tmp_path))),
+        _projection_spec(),
+    )
+    payload = run.result
+    target = next(
+        item
+        for item in payload["measurement_artifacts"]
+        if item["record_scope"] == "role" and item["record_id"] == "target"
+    )
+    target["evidence_state"] = "negative"
+
+    with pytest.raises(
+        ValueError,
+        match="measurement evidence must match its source record state",
+    ):
+        OffTargetControlProfileV2.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    ("change", "reason"),
+    [
+        (
+            lambda payload: payload.update({"tool_refs": []}),
+            "measurement_spec_tool_not_authorized",
+        ),
+        (
+            lambda payload: payload["raw_metric_definition"].update(
+                {"metric_names": ["off_target_role_composition"]}
+            ),
+            "measurement_spec_metric_names_mismatch",
+        ),
+    ],
+)
+def test_measurement_spec_authorization_fails_closed(
+    tmp_path: Path,
+    change: Callable[[dict], None],
+    reason: str,
+) -> None:
+    request = _projection_request(_with_measurement_spec(_request(tmp_path)))
+    request = _rewrite(request, "measurement_spec", change)
+
+    eligibility = adapter.check_eligibility(request, _projection_spec())
+
+    assert not eligibility.eligible
+    assert reason in eligibility.reason_codes
+
+
+def test_projection_preserves_partial_unknown_and_withholds_unavailable_values(
+    tmp_path: Path,
+) -> None:
+    request = _rewrite(
+        _with_measurement_spec(_request(tmp_path)),
+        "off_target_evidence_bundle",
+        lambda payload: payload.update(
+            {
+                "composition_coverage_state": "partial",
+                "unknown_coverage_state": "partial",
+                "state_observations": [
+                    {"state_id": "state:a", "soft_mass": 7.0, "observed_count": 7},
+                    {"state_id": "state:b", "soft_mass": 0.0, "observed_count": 0},
+                ],
+            }
+        ),
+    )
+    request = _projection_request(request)
+
+    run = adapter.run(request, _projection_spec())
+
+    target = _projected_measurement(run, "role", "target")
+    assert target.evidence_state.value == "unavailable"
+    assert target.raw_value is None
+    assert target.score_state.value == "unavailable"
+    assert target.numerator is None
+    assert target.denominator is None
+    unknown = _projected_measurement(run, "identity_unknown", "identity-unknown")
+    assert unknown.evidence_state.value == "unknown"
+    assert unknown.unknown_scope == "identity"
+    assert unknown.raw_value == run.result["unknown_profile"]
+    rare = _projected_measurement(run, "rare_state", "state:b")
+    assert rare.evidence_state.value == "unknown"
+    assert rare.unknown_scope == "measurement"
+    assert rare.raw_value is None
+    assert rare.score_state.value == "unavailable"
+    assert run.result["rare_state_profile"][0]["observed_count"] == 0
+    assert run.result["rare_state_profile"][0]["detection_state"] == "cannot_exclude"
+
+
+def test_projection_maps_calibrated_zero_to_negative_without_absence_claim(
+    tmp_path: Path,
+) -> None:
+    def zero_rare_state(payload: dict) -> None:
+        payload["state_observations"] = [
+            {"state_id": "state:a", "soft_mass": 9.0, "observed_count": 9},
+            {"state_id": "state:b", "soft_mass": 0.0, "observed_count": 0},
+        ]
+
+    request = _rewrite(
+        _with_measurement_spec(_request(tmp_path)),
+        "off_target_evidence_bundle",
+        zero_rare_state,
+    )
+    request = _projection_request(request)
+
+    run = adapter.run(request, _projection_spec())
+    rare = _projected_measurement(run, "rare_state", "state:b")
+
+    assert rare.evidence_state.value == "negative"
+    assert rare.raw_value["detection_state"] == "not_detected_above_lod"
+    assert rare.raw_value["observed_count"] == 0
+    assert "zero_observation_does_not_establish_absence" in rare.raw_value[
+        "reason_codes"
+    ]
+
+
+def test_projection_maps_missing_rare_observation_to_unavailable(
+    tmp_path: Path,
+) -> None:
+    def remove_rare_row(payload: dict) -> None:
+        payload["composition_coverage_state"] = "partial"
+        payload["unknown_coverage_state"] = "not_assessed"
+        payload["state_observations"] = payload["state_observations"][:1]
+
+    request = _rewrite(
+        _with_measurement_spec(_request(tmp_path)),
+        "off_target_evidence_bundle",
+        remove_rare_row,
+    )
+    request = _projection_request(request)
+    run = adapter.run(request, _projection_spec())
+    rare = _projected_measurement(run, "rare_state", "state:b")
+
+    assert rare.evidence_state.value == "unavailable"
+    assert rare.raw_value is None
+    assert rare.numerator is None
+    assert rare.denominator is None
+    unknown = _projected_measurement(run, "identity_unknown", "identity-unknown")
+    assert unknown.evidence_state.value == "unavailable"
+    assert unknown.raw_value is None
+    assert run.result["rare_state_profile"][0]["observed_count"] is None
+    assert run.result["rare_state_profile"][0]["reason_codes"] == [
+        "rare_state_observation_missing"
+    ]
 
 
 def test_product_figure_discloses_soft_mass_denominator(

--- a/tests/test_p0_05_real_methods.py
+++ b/tests/test_p0_05_real_methods.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from bridge.tool_packages.p0_05_off_target_control.adapter import adapter
 from bridge.tool_packages.p0_05_off_target_control.visualization import (
     prepare_off_target_control_visualizations,
 )
@@ -19,7 +20,14 @@ from bridge.tool_packages.p0_05_off_target_control.visualization_data import (
 from bridge.toolkit.contracts import ExecutionState, StructuredInputRef, ToolRequestV2
 from bridge.toolkit.registry import ToolRegistry
 from p0_biological_units import bind_reviewed_biological_units
-from test_p0_05_off_target_control import _encoded, _request, _write
+from test_p0_05_off_target_control import (
+    _encoded,
+    _projection_request,
+    _projection_spec,
+    _request,
+    _with_measurement_spec,
+    _write,
+)
 
 
 METHOD_ROLE_SCHEMAS = {
@@ -374,6 +382,49 @@ def _rewrite_method(request: ToolRequestV2, role: str, change) -> ToolRequestV2:
     return request.model_copy(update={"object_inputs": refs})
 
 
+def _method_request_with_measurement_spec(tmp_path: Path) -> ToolRequestV2:
+    request = _projection_request(
+        _with_measurement_spec(_method_request(tmp_path))
+    )
+    measurement_sha = next(
+        item.sha256 for item in request.object_inputs if item.role == "measurement_spec"
+    )
+    request = _rewrite_method(
+        request,
+        "cell_state_evidence_profile",
+        lambda payload: payload.update(
+            {"measurement_spec_sha256": measurement_sha}
+        ),
+    )
+    profile_sha = next(
+        item.sha256
+        for item in request.object_inputs
+        if item.role == "cell_state_evidence_profile"
+    )
+    request = _rewrite_method(
+        request,
+        "off_target_evidence_bundle",
+        lambda payload: payload.update(
+            {"cell_state_profile_sha256": profile_sha}
+        ),
+    )
+    evidence_sha = next(
+        item.sha256
+        for item in request.object_inputs
+        if item.role == "off_target_evidence_bundle"
+    )
+    return _rewrite_method(
+        request,
+        "off_target_method_input",
+        lambda payload: payload.update(
+            {
+                "cell_state_profile_sha256": profile_sha,
+                "evidence_bundle_sha256": evidence_sha,
+            }
+        ),
+    )
+
+
 def test_method_mode_executes_eight_transparent_methods(tmp_path: Path) -> None:
     registry = ToolRegistry.load_default()
     request = _method_request(tmp_path)
@@ -459,6 +510,42 @@ def test_method_mode_executes_eight_transparent_methods(tmp_path: Path) -> None:
     assert product_figure.data_binding.interval_lower_field == "soft_interval_lower"
     assert product_figure.data_binding.interval_upper_field == "soft_interval_upper"
     assert first.run_id != different_seed.run_id
+
+
+def test_method_mode_can_opt_into_measurement_projection(tmp_path: Path) -> None:
+    request = _method_request_with_measurement_spec(tmp_path)
+
+    registry = ToolRegistry.load_default()
+    assert registry.check_eligibility(request).eligible
+    run = registry.run(request)
+
+    assert run.execution_state is ExecutionState.SUCCEEDED
+    assert run.result["object_version"] == "0.2.0"
+    assert run.result_schema_ref == _projection_spec().result_schema_ref
+    assert run.result["measurement_projection_state"] == "available"
+    assert len(run.measurements) == 6
+    assert len(
+        [item for item in run.artifacts if item.kind == "measurement_result_v2"]
+    ) == 6
+    assert any(item.kind == "off_target_method_bundle" for item in run.artifacts)
+    assert len(run.artifacts) == 22
+
+
+def test_method_mode_rejects_measurement_spec_checksum_drift(
+    tmp_path: Path,
+) -> None:
+    request = _rewrite_method(
+        _method_request_with_measurement_spec(tmp_path),
+        "measurement_spec",
+        lambda payload: payload.update(
+            {"scientific_question": "A changed projection contract"}
+        ),
+    )
+
+    eligibility = adapter.check_eligibility(request, _projection_spec())
+
+    assert not eligibility.eligible
+    assert "measurement_spec_checksum_mismatch" in eligibility.reason_codes
 
 
 def test_method_mode_partial_coverage_withholds_intervals(tmp_path: Path) -> None:
@@ -763,7 +850,7 @@ def test_renderer_retains_more_than_five_spike_in_states(
         profile=profile,
         output_dir=tmp_path / "rerender",
         run_id=run.run_id,
-        tool_version="0.4.0",
+        tool_version="0.5.0",
     )
     svg = rendered.payloads[
         "off_target_control_rare-state-detectability.svg"


### PR DESCRIPTION
## Summary

- accept an optional checksummed `MeasurementSpecV2` in both P0-05 execution modes
- project existing role-composition, identity-unknown, and rare-state observations into checksummed `MeasurementResultV2` artifacts
- retain the v0.1 profile schema and preserve missing, unknown, negative, and unavailable semantics without zero imputation
- keep `domain_score=null` and `score_state=unavailable`

## Contract boundaries

This change projects existing P0-05 observations only. It adds no biological thresholds, classification rules, safety interpretation, or release authority.

## Validation

- 183 focused and shared-contract tests passed
- generated schema export is idempotent and the public schema matches runtime validation
- repository policy and diff checks passed
- clean-wheel `describe` and `input-contract` smoke passed
- independent final review found no remaining Critical or Important issues
