### PR TITLE
fix: normalize duplicate raw gene symbols in P0-02

### DIFF
--- a/docs/bridge_spec_v0.1/cell_state_annotation_task_card.md
+++ b/docs/bridge_spec_v0.1/cell_state_annotation_task_card.md
@@ -9,7 +9,7 @@
 | 适用范围 | 移植前 scRNA-seq / snRNA-seq；PD hPSC-mDA 为首个实例 |
 | Annotation snapshot | `BRIDGE-PD-vMB-ANNOTATION-v0.1-draft` |
 | 主要输出 | `CellStateEvidenceProfile` |
-| 当前实现 | P0-02 v0.5.2 可执行 shadow baseline；新增可追溯的层级对应图和静态状态定义证据登记矩阵 |
+| 当前实现 | P0-02 v0.5.2 可执行 shadow baseline；含可追溯层级对应图、静态状态定义证据矩阵及 raw-count 重复基因规范化审计 |
 
 ## 1. 任务目标
 

--- a/src/bridge/tool_packages/cards/P0-02.md
+++ b/src/bridge/tool_packages/cards/P0-02.md
@@ -43,6 +43,8 @@ Produce source-aware reference and marker-program evidence against the internal 
 
 **Input:** QC-qualified expression views with required `source_family_id` and `qc_profile_ref` asset metadata, a MeasurementSpec reference, declared scRNA/snRNA modality, annotation vocabulary, reference candidates and provenance. The optional V3 handoff resolves the deployment-catalogued P0-01 structured-output index named by `qc_profile_ref`, including checksummed QC V2, biological-unit assignment and manifest artifacts.
 
+For raw-count inputs, feature columns resolving to the same non-missing normalized gene symbol are summed before normalization and recorded as a warning. Normalized-expression inputs must already have unique gene symbols.
+
 **Output:** Backward-compatible Cell-State evidence plus an optional candidate-only V3 profile, a typed whole-product reference-correspondence figure, and a static state-definition evidence registry. Every typed figure binds its complete table, static renders, exact data hash and evidence references; no output assigns a domain score.
 
 **Runtime behavior:** Executable candidate; it emits raw measurements and never emits a domain score.

--- a/src/bridge/tool_packages/p0_02_cell_state/README.md
+++ b/src/bridge/tool_packages/p0_02_cell_state/README.md
@@ -6,7 +6,9 @@ package. Its output remains shadow without a signed release manifest.
 ## Interface at a glance
 
 - **Input:** QC-qualified expression views, modality, annotation vocabulary,
-  reference candidates and provenance; an optional typed P0-01 handoff.
+  reference candidates and provenance; an optional typed P0-01 handoff. Raw-count
+  columns that resolve to the same non-missing gene symbol are summed before
+  normalization; duplicate symbols in normalized inputs remain invalid.
 - **Output:** source-aware reference and marker/program evidence plus an optional
   V3 profile with explicit denominators, uncertainty and lineage bindings.
 - **Boundary:** it does not release an assigned state or domain score. Pseudobulk

--- a/src/bridge/tool_packages/p0_02_cell_state/executor.py
+++ b/src/bridge/tool_packages/p0_02_cell_state/executor.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+from scipy import sparse
 
 from bridge.tool_packages.p0_01_input_qc.io import (
     InputAuditError,
@@ -148,12 +149,26 @@ def run_cell_state_evidence(request: ToolRequest, spec: ToolPackageSpec) -> Tool
         adata = read_expression_asset(asset)
         validate_expression_object(adata, require_counts=asset.matrix_semantics == "raw_counts")
         genes = _declared_gene_names(adata, asset.metadata)
+        query_matrix = adata.X
+        preprocessing_warnings: list[str] = []
+        if len(set(genes)) != len(genes):
+            if asset.matrix_semantics != "raw_counts":
+                raise InputAuditError(
+                    "gene_ids_not_unique_after_normalization",
+                    str(asset.metadata.get("gene_symbol_column") or "var_names"),
+                )
+            query_matrix, genes, collapsed_count = _collapse_duplicate_gene_counts(
+                query_matrix, genes
+            )
+            preprocessing_warnings.append(
+                f"duplicate_gene_symbols_collapsed:{collapsed_count}"
+            )
     except (InputAuditError, ReferenceError) as exc:
         return _failed_run(request, spec, input_hash, exc.reason_code, str(exc))
     except Exception as exc:
         return _failed_run(request, spec, input_hash, "cell_state_input_read_failed", str(exc))
 
-    query = normalize_query(adata.X, asset.matrix_semantics or "")
+    query = normalize_query(query_matrix, asset.matrix_semantics or "")
     observation_ids = adata.obs_names.astype(str).to_numpy()
     selected_data_view = None
     if (
@@ -183,7 +198,11 @@ def run_cell_state_evidence(request: ToolRequest, spec: ToolPackageSpec) -> Tool
     source_summaries: list[pd.DataFrame] = []
     primary_source_ids: list[str] = []
     coverage_records: list[dict[str, Any]] = []
-    warnings = ["open_set_calibration_not_frozen", "marker_programs_are_shadow_candidates"]
+    warnings = [
+        "open_set_calibration_not_frozen",
+        "marker_programs_are_shadow_candidates",
+        *preprocessing_warnings,
+    ]
     query_source_family = canonicalize_source_family_id(str(asset.metadata["source_family_id"]))
     held_out_sources = sorted(
         profile.source_id
@@ -340,7 +359,7 @@ def run_cell_state_evidence(request: ToolRequest, spec: ToolPackageSpec) -> Tool
         annotation_vocabulary_ref=vocabulary.vocabulary_id,
         reference_snapshot_ref=manifest.snapshot_id,
         n_observations=int(adata.n_obs),
-        n_genes=int(adata.n_vars),
+        n_genes=int(len(genes)),
         denominator="all observations in the declared post-QC input view",
         label_levels={
             "L1": {"state": "shadow", "n_observations": int(adata.n_obs)},
@@ -1127,10 +1146,33 @@ def _declared_gene_names(adata, metadata: dict[str, Any]) -> np.ndarray:
     if column is not None and column not in adata.var:
         raise InputAuditError("gene_symbol_column_not_found", str(column))
     values = adata.var_names if column is None else adata.var[column]
+    if bool(np.asarray(pd.isna(values), dtype=bool).any()):
+        raise InputAuditError("empty_gene_id_after_normalization", column or "var_names")
     genes = np.asarray([str(value).strip().upper() for value in values])
-    if len(set(genes)) != len(genes):
-        raise InputAuditError("gene_ids_not_unique_after_normalization", column or "var_names")
+    if any(not gene for gene in genes):
+        raise InputAuditError("empty_gene_id_after_normalization", column or "var_names")
     return genes
+
+
+def _collapse_duplicate_gene_counts(
+    matrix: Any,
+    genes: np.ndarray,
+) -> tuple[Any, np.ndarray, int]:
+    """Sum raw-count columns that resolve to the same normalized gene symbol."""
+
+    unique_genes, inverse = np.unique(genes, return_inverse=True)
+    collapsed_count = int(len(genes) - len(unique_genes))
+    if collapsed_count == 0:
+        return matrix, genes, 0
+    source_to_target = sparse.csr_matrix(
+        (
+            np.ones(len(genes), dtype=np.int64),
+            (np.arange(len(genes)), inverse),
+        ),
+        shape=(len(genes), len(unique_genes)),
+    )
+    source = matrix if sparse.issparse(matrix) else sparse.csr_matrix(matrix)
+    return (source @ source_to_target).tocsr(), unique_genes, collapsed_count
 
 
 def _run_id(

--- a/tests/test_cell_state.py
+++ b/tests/test_cell_state.py
@@ -472,6 +472,91 @@ def test_source_aware_run_emits_shadow_support_and_preserves_input(tmp_path: Pat
     )
 
 
+def test_raw_counts_with_duplicate_gene_symbols_are_collapsed_without_mutating_input(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _build_snapshot(tmp_path, monkeypatch)
+    base = np.vstack(
+        [
+            _expression(label, replicate=index % 2)
+            for index, label in enumerate(
+                ["Neuron_DA", "Neuron_DA", "Astrocyte", "Astrocyte"]
+            )
+        ]
+    )
+    matrix = np.column_stack([base, base[:, GENES.index("G000")]])
+    symbols = [*GENES, "G000"]
+    query = tmp_path / "query-duplicate-symbols.h5ad"
+    ad.AnnData(
+        sparse.csr_matrix(matrix),
+        obs=pd.DataFrame(index=[f"query-{index}" for index in range(4)]),
+        var=pd.DataFrame(
+            {"gene_symbol": symbols},
+            index=[f"gene-id-{index}" for index in range(len(symbols))],
+        ),
+    ).write_h5ad(query)
+    _configure_qc_catalog(tmp_path, monkeypatch, query)
+    before = _sha256(query)
+    request = _request(tmp_path, query)
+    request = request.model_copy(
+        update={
+            "assets": [
+                request.assets[0].model_copy(
+                    update={
+                        "metadata": {
+                            **request.assets[0].metadata,
+                            "gene_symbol_column": "gene_symbol",
+                        }
+                    }
+                )
+            ]
+        }
+    )
+
+    run = ToolRegistry.load_default().run(request)
+
+    assert run.execution_state is ExecutionState.SUCCEEDED
+    assert run.result["n_genes"] == len(GENES)
+    assert "duplicate_gene_symbols_collapsed:1" in run.warnings
+    assert _sha256(query) == before
+
+
+@pytest.mark.parametrize("as_sparse", [False, True])
+def test_duplicate_gene_count_collapse_sums_columns_and_preserves_total(
+    as_sparse: bool,
+) -> None:
+    source = np.asarray([[1, 2, 3], [4, 5, 6]], dtype=np.int64)
+    matrix = sparse.csr_matrix(source) if as_sparse else source
+
+    collapsed, genes, removed = cell_state_executor._collapse_duplicate_gene_counts(
+        matrix, np.asarray(["A", "B", "A"])
+    )
+
+    assert sparse.isspmatrix_csr(collapsed)
+    assert genes.tolist() == ["A", "B"]
+    assert removed == 1
+    np.testing.assert_array_equal(collapsed.toarray(), [[4, 2], [10, 5]])
+    assert int(collapsed.sum()) == int(source.sum())
+
+
+@pytest.mark.parametrize("missing", [None, pd.NA, np.nan])
+def test_declared_gene_symbols_reject_missing_values(missing: object) -> None:
+    data = ad.AnnData(
+        np.ones((1, 2)),
+        var=pd.DataFrame(
+            {"gene_symbol": ["GENE1", missing]},
+            index=["feature-1", "feature-2"],
+        ),
+    )
+
+    with pytest.raises(cell_state_executor.InputAuditError) as error:
+        cell_state_executor._declared_gene_names(
+            data, {"gene_symbol_column": "gene_symbol"}
+        )
+
+    assert error.value.reason_code == "empty_gene_id_after_normalization"
+
+
 def test_reference_build_normalizes_neuron_chat_alias(tmp_path: Path, monkeypatch) -> None:
     snapshot = _build_snapshot(tmp_path, monkeypatch, alias=True)
 


### PR DESCRIPTION
## Scope

- normalize non-missing raw-count gene symbols before analysis
- sum duplicate raw-count feature columns without densifying sparse matrices
- reject missing/empty gene identifiers and keep normalized-expression inputs strict
- report the number of unique analyzed genes

## Verification

- P0-02 focused suite: 45 passed
- repository policy: passed
- diff hygiene: passed

Scientific status is unchanged: candidate/shadow, with no domain score or release claim.