### PR TITLE
fix: align P0-03 domain input contracts

### DIFF
--- a/docs/bridge_spec_v0.1/target_regional_identity_task_card.md
+++ b/docs/bridge_spec_v0.1/target_regional_identity_task_card.md
@@ -12,7 +12,11 @@
 
 ## 0. 当前可执行候选
 
-P0-03 v0.4.0 提供两个兼容入口：
+P0-03 v0.4.1 提供两个兼容入口：
+
+ProductCase 与 P0-02 profile 继续绑定 cell-state source MeasurementSpec；
+P0-03 的 `measurement_spec` 是独立的域测量合同，负责本模块的 assay、工具授权、
+分析单位与输出指标，两者不得被误当成同一份对象。
 
 - **聚合模式**：读取 11 个 checksummed JSON，发布三个分母明确的
   `MeasurementResultV2` 与 `TargetRegionalEvidenceResult`。
@@ -44,7 +48,7 @@ NNLS 的 relative L2 residual 上限同样来自外部 applicability contract；
 空间投射尚未进入本版本。所有数值仍为 `shadow`，`domain_score=null`；真实
 方法可执行不等于 reference、program 或产品结论已经过生物学验证。
 
-v0.4.0 同时从同一 typed data object 生成两类正式图形：完整产品的角色及具名区域
+v0.4.1 同时从同一 typed data object 生成两类正式图形：完整产品的角色及具名区域
 状态组成，以及按 target identity / regional fidelity、reference source 和 assay
 分开的表达支持矩阵。图、精确 TSV 与 JSON 绑定同一 hash；未评估、部分可用和
 草案审核状态不会被隐藏。相关性只表示 reference-conditioned expression support，
@@ -197,7 +201,7 @@ Web 可以突出展示 cell-level 投射图；正式可比较 raw metrics 先按
 
 ## 9. 运行环境
 
-P0-03 v0.4.0 的聚合与当前表达方法均在冻结的
+P0-03 v0.4.1 的聚合与当前表达方法均在冻结的
 `ENV-CELLSTATE-PY-v0.1` 中运行。AnnData 负责 H5AD I/O，NumPy/pandas/SciPy
 负责 pseudobulk、correlation、NNLS 和 bootstrap，decoupler 负责 ULM。
 
@@ -209,7 +213,7 @@ SpatialData、Squidpy、Tangram、SpaOTsc、CellTrek、CytoSPACE 和 cell2locati
 
 ## 10. 当前可视化与后续下钻
 
-P0-03 v0.4.0 当前生成：
+P0-03 v0.4.1 当前生成：
 
 - **产品相关细胞组成与区域状态图**：同时显示完整产品中
   target、acceptable adjacent、known off-target、unresolved、unknown、OOD 和

--- a/examples/requests/p0_03_target_regional_evidence.json
+++ b/examples/requests/p0_03_target_regional_evidence.json
@@ -107,5 +107,5 @@
   "random_seed": 0,
   "request_id": "example-p0-03-documentation-only",
   "tool_id": "P0-03",
-  "tool_version": "0.4.0"
+  "tool_version": "0.4.1"
 }

--- a/examples/requests/p0_03_target_regional_expression.json
+++ b/examples/requests/p0_03_target_regional_expression.json
@@ -1,7 +1,7 @@
 {
   "request_id": "example-p0-03-expression-documentation-only",
   "tool_id": "P0-03",
-  "tool_version": "0.4.0",
+  "tool_version": "0.4.1",
   "output_dir": "/absolute/path/to/output",
   "assets": [
     {

--- a/src/bridge/tool_packages/_configurable_contracts.py
+++ b/src/bridge/tool_packages/_configurable_contracts.py
@@ -26,6 +26,7 @@ from bridge.toolkit.contracts import (
     IndependenceGroupKind,
     MeasurementSpecV2,
     QCReadinessProfileV2,
+    ReadinessState,
 )
 
 OBJECT_ID_PATTERN = r"^[A-Za-z][A-Za-z0-9._:-]*$"
@@ -801,11 +802,28 @@ def parse_composition(
     return records
 
 
+def qc_allows_module(qc_profile: QCReadinessProfileV2, tool_id: str) -> bool:
+    """Interpret an explicit module gate before the generic downstream gate."""
+
+    if qc_profile.readiness_state in {
+        ReadinessState.BLOCKED,
+        ReadinessState.NOT_ASSESSED,
+        ReadinessState.NOT_APPLICABLE,
+    }:
+        return False
+    explicit = qc_profile.module_eligibility.get(tool_id)
+    if explicit is not None:
+        return explicit in {"eligible", "conditional"}
+    return qc_profile.module_eligibility.get(
+        "downstream_scientific_modules"
+    ) in {"eligible", "conditional"}
+
+
 def profile_lineage_reasons(
     *,
     product_case: ProductCase,
     cell_state_profile: CellStateEvidenceProfileV2,
-    measurement_spec: MeasurementSpecV2,
+    measurement_spec: MeasurementSpecV2 | None,
     qc_profile: QCReadinessProfileV2,
     biological_unit_manifest: BiologicalUnitManifest,
     biological_unit_assignment_artifact: BiologicalUnitAssignmentArtifact,
@@ -899,23 +917,31 @@ def profile_lineage_reasons(
     ):
         reasons.append("cell_state_qc_profile_checksum_mismatch")
     if (
-        measurement_spec.measurement_spec_id
+        cell_state_profile.measurement_spec_id
         != product_case.measurement_spec_ref.object_id
-        or measurement_spec.version
-        != product_case.measurement_spec_ref.object_version
-        or cell_state_profile.measurement_spec_id
-        != measurement_spec.measurement_spec_id
         or cell_state_profile.measurement_spec_version
-        != measurement_spec.version
+        != product_case.measurement_spec_ref.object_version
     ):
         reasons.append("measurement_spec_binding_mismatch")
-    if (
-        measurement_spec.analysis_unit_kind
-        != biological_unit_manifest.analysis_unit_kind
-        or measurement_spec.independence_group_kind
-        != biological_unit_manifest.independence_group_kind
-    ):
-        reasons.append("measurement_spec_biological_unit_mismatch")
+    if measurement_spec is not None:
+        if (
+            measurement_spec.measurement_spec_id
+            != product_case.measurement_spec_ref.object_id
+            or measurement_spec.version
+            != product_case.measurement_spec_ref.object_version
+            or cell_state_profile.measurement_spec_id
+            != measurement_spec.measurement_spec_id
+            or cell_state_profile.measurement_spec_version
+            != measurement_spec.version
+        ):
+            reasons.append("measurement_spec_binding_mismatch")
+        if (
+            measurement_spec.analysis_unit_kind
+            != biological_unit_manifest.analysis_unit_kind
+            or measurement_spec.independence_group_kind
+            != biological_unit_manifest.independence_group_kind
+        ):
+            reasons.append("measurement_spec_biological_unit_mismatch")
 
     if cell_state_view is not None:
         try:

--- a/src/bridge/tool_packages/cards/P0-03.md
+++ b/src/bridge/tool_packages/cards/P0-03.md
@@ -11,7 +11,7 @@ regional evidence methods on the exact QC-selected H5AD view.
 
 | Field | Value |
 |---|---|
-| Package version | `0.4.0` |
+| Package version | `0.4.1` |
 | Runtime state | `implemented` |
 | Scientific state | `candidate` |
 | Optional | `no` |
@@ -42,12 +42,12 @@ regular-file path and SHA-256.
 
 | Role | Schema | Version rule | Meaning |
 |---|---|---|---|
-| `product_case` | `bridge://schemas/product-case/v0.1` | `0.1.0` | Product, source unit, MeasurementSpec, data-view and lineage scope |
+| `product_case` | `bridge://schemas/product-case/v0.1` | `0.1.0` | Product, source unit, P0-02 source MeasurementSpec, data-view and lineage scope |
 | `product_definition_card` | `bridge://schemas/product-definition-card/v0.1` | `0.1.0` | Assay scope and exact StateRoleMap reference |
 | `state_role_map` | `bridge://schemas/state-role-map/v0.1` | `0.1.0` | Shared P0-05-owned state-to-product-role contract, consumed without redefinition |
 | `target_regional_assessment_spec` | `bridge://schemas/target-regional-assessment-spec/v0.1` | `0.1.0` | Exact StateRoleMap checksum, requested channels, target product roles and regional state-ID sets |
-| `measurement_spec` | `bridge://schemas/measurement-spec/v0.2` | payload `version` | Units, applicable context and provenance contract |
-| `cell_state_evidence_profile` | `bridge://schemas/cell-state-evidence-profile/v0.3` | `0.3.0` | Typed P0-02 composition and MeasurementSpec/vocabulary/reference/QC checksums |
+| `measurement_spec` | `bridge://schemas/measurement-spec/v0.2` | payload `version` | P0-03 metric, assay, unit, applicability and provenance contract |
+| `cell_state_evidence_profile` | `bridge://schemas/cell-state-evidence-profile/v0.3` | `0.3.0` | Typed P0-02 composition and source-MeasurementSpec/vocabulary/reference/QC checksums |
 | `qc_readiness_profile` | `bridge://schemas/qc-readiness-profile/v0.2` | `0.2.0` | P0-01 readiness, module eligibility and selected DataView |
 | `biological_unit_manifest` | `bridge://schemas/biological-unit-manifest/v0.1` | `0.1.0` | Observation, analysis-unit and independence-group lineage |
 | `biological_unit_assignment` | `bridge://schemas/biological-unit-assignment/v0.1` | `0.1.0` | Observation-to-unit assignments bound by the manifest |
@@ -64,13 +64,15 @@ and parent asset checksum; both are matched to P0-01/P0-02 lineage. Top-level
 
 ## Binding and calculation
 
-Eligibility fails closed unless ProductCase, ProductDefinitionCard,
-MeasurementSpec, selected DataView, QC profile, biological-unit manifest and
-assignment all describe the same case and lineage. The adapter also requires
-the P0-02 V3 MeasurementSpec, AnnotationVocabulary, ReferenceManifest and QC
-SHA-256 values to equal the supplied object checksums. Vocabulary IDs/versions,
-reference IDs/versions, label levels, source IDs, shared StateRoleMap
-ref/checksum and P0-03 QC eligibility must agree.
+Eligibility fails closed unless ProductCase, ProductDefinitionCard, selected
+DataView, QC profile, biological-unit manifest and assignment describe the same
+case and lineage. ProductCase and the P0-02 V3 profile must bind the same source
+MeasurementSpec, and that source spec ID must belong to the P0-02 reference
+manifest. The separate P0-03 MeasurementSpec must authorize P0-03 and match the
+case assay, product applicability, analysis unit and independence group.
+Vocabulary IDs/versions, reference IDs/versions and checksums, label levels,
+source IDs, shared StateRoleMap ref/checksum and explicit or generic QC
+eligibility must also agree.
 
 All biological choices are external. The shared `StateRoleMap` owns product
 roles. `TargetRegionalAssessmentSpec` owns requested views/sources/levels, the
@@ -113,7 +115,7 @@ the supplied `ReferenceManifest` and verified by checksum before use.
 
 CellTypist, scANVI, SingleR, scmap, Symphony and scConform remain P0-02 benchmark
 adapters whose evidence can enter through the P0-02 profile. Spatial methods in
-the catalog remain conditional and are not invoked by P0-03 v0.4.0.
+the catalog remain conditional and are not invoked by P0-03 v0.4.1.
 
 For every requested channel the executor emits only these ratio types:
 

--- a/src/bridge/tool_packages/p0_03_target_regional/README.md
+++ b/src/bridge/tool_packages/p0_03_target_regional/README.md
@@ -13,6 +13,9 @@ This directory contains the target and regional evidence package.
 - **Configuration:** target/regional references, expression semantics, matched
   modality groups, NNLS residual applicability, program cards, gene-coverage
   minima and biological roles are versioned inputs.
+- **Contract separation:** the ProductCase and P0-02 profile retain their
+  cell-state source MeasurementSpec; P0-03 receives its own MeasurementSpec for
+  target/regional metrics, assay, units and tool authorization.
 - **Boundary:** transcriptomic regional support is not spatial localization;
   `domain_score` remains null.
 

--- a/src/bridge/tool_packages/p0_03_target_regional/adapter.py
+++ b/src/bridge/tool_packages/p0_03_target_regional/adapter.py
@@ -14,6 +14,7 @@ from bridge.tool_packages._configurable_contracts import (
     StateRoleMap,
     VersionedObjectRef,
     profile_lineage_reasons,
+    qc_allows_module,
 )
 from bridge.tool_packages.p0_01_input_qc.io import InputAuditError, sha256_path
 from bridge.tool_packages._structured_runtime import (
@@ -58,7 +59,6 @@ from bridge.toolkit.contracts import (
     ImplementationState,
     MeasurementSpecV2,
     QCReadinessProfileV2,
-    ReadinessState,
     ReferenceManifest,
     StructuredInputRef,
     ToolPackageSpecV2,
@@ -573,7 +573,7 @@ def _binding_reasons(
         profile_lineage_reasons(
             product_case=product_case,
             cell_state_profile=cell_state_profile,
-            measurement_spec=measurement_spec,
+            measurement_spec=None,
             qc_profile=qc_profile,
             biological_unit_manifest=biological_unit_manifest,
             biological_unit_assignment_artifact=biological_unit_assignment,
@@ -596,6 +596,15 @@ def _binding_reasons(
         reasons.append("product_case_assay_not_supported")
     if measurement_spec.assay != product_case.assay:
         reasons.append("measurement_spec_assay_mismatch")
+    if "P0-03" not in measurement_spec.tool_refs:
+        reasons.append("measurement_spec_tool_not_authorized")
+    if (
+        measurement_spec.analysis_unit_kind
+        != biological_unit_manifest.analysis_unit_kind
+        or measurement_spec.independence_group_kind
+        != biological_unit_manifest.independence_group_kind
+    ):
+        reasons.append("measurement_spec_biological_unit_mismatch")
     if (
         measurement_spec.applicable_product_cards
         and product_definition.product_definition_id
@@ -607,21 +616,8 @@ def _binding_reasons(
         reasons.append("cell_state_profile_assay_mismatch")
     if qc_profile.assay != product_case.assay:
         reasons.append("qc_profile_assay_mismatch")
-    if (
-        qc_profile.readiness_state
-        in {
-            ReadinessState.BLOCKED,
-            ReadinessState.NOT_ASSESSED,
-            ReadinessState.NOT_APPLICABLE,
-        }
-        or qc_profile.module_eligibility.get("P0-03") != "eligible"
-    ):
+    if not qc_allows_module(qc_profile, "P0-03"):
         reasons.append("qc_not_ready_for_target_regional_evidence")
-    if (
-        cell_state_profile.measurement_spec_sha256
-        != input_sha256_by_role["measurement_spec"]
-    ):
-        reasons.append("measurement_spec_checksum_mismatch")
     if (
         cell_state_profile.annotation_vocabulary_ref
         != annotation_vocabulary.vocabulary_id
@@ -646,11 +642,8 @@ def _binding_reasons(
         != input_sha256_by_role["reference_manifest"]
     ):
         reasons.append("reference_manifest_checksum_mismatch")
-    if (
-        measurement_spec.measurement_spec_id
-        not in reference_manifest.measurement_spec_ids
-    ):
-        reasons.append("reference_manifest_measurement_spec_mismatch")
+    if cell_state_profile.measurement_spec_id not in reference_manifest.measurement_spec_ids:
+        reasons.append("cell_state_measurement_spec_reference_mismatch")
     if measurement_spec.reference_refs and not {
         reference_manifest.snapshot_id,
         f"{reference_manifest.snapshot_id}@{reference_manifest.version}",
@@ -698,12 +691,6 @@ def _binding_reasons(
     ):
         reasons.append("cell_state_vocabulary_label_mismatch")
     reasons.extend(_product_case_source_reasons(product_case, biological_unit_manifest))
-    if (
-        qc_profile.measurement_spec_version != measurement_spec.version
-        or qc_profile.measurement_spec_status != measurement_spec.status
-        or cell_state_profile.measurement_spec_status != measurement_spec.status
-    ):
-        reasons.append("measurement_spec_profile_binding_mismatch")
     if any(
         not EVIDENCE_REF.fullmatch(evidence_ref)
         for evidence_ref in [*cell_state_profile.evidence_ids, *qc_profile.evidence_ids]

--- a/src/bridge/tool_packages/specs/p0_03.yaml
+++ b/src/bridge/tool_packages/specs/p0_03.yaml
@@ -1,6 +1,6 @@
 tool_id: P0-03
 name: Target Identity & Regional Fidelity
-version: 0.4.0
+version: 0.4.1
 summary: Run configured target/regional expression methods and aggregate role-bound evidence.
 implementation_state: implemented
 scientific_status: candidate

--- a/tests/test_p0_03_target_regional.py
+++ b/tests/test_p0_03_target_regional.py
@@ -87,7 +87,7 @@ def _base_payloads() -> dict[str, dict]:
                 "object_version": "1.0.0",
             },
             "measurement_spec_ref": {
-                "object_id": "measurement-spec:target-regional-demo",
+                "object_id": "measurement-spec:cell-state-source",
                 "object_version": "1.0.0",
             },
             "assay": "scRNA-seq",
@@ -253,7 +253,7 @@ def _base_payloads() -> dict[str, dict]:
             "vocabulary_sha256": "0" * 64,
             "marker_program_file": "marker_programs.json",
             "marker_program_sha256": "d" * 64,
-            "measurement_spec_ids": ["measurement-spec:target-regional-demo"],
+            "measurement_spec_ids": ["measurement-spec:cell-state-source"],
             "profiles": [],
             "prohibited_source_families": [],
         },
@@ -315,12 +315,12 @@ def _prepare(payloads: dict[str, dict]) -> None:
     vocabulary = payloads["annotation_vocabulary"]
     reference = payloads["reference_manifest"]
     reference["vocabulary_sha256"] = _sha(vocabulary)
-    measurement = payloads["measurement_spec"]
+    source_measurement_ref = payloads["product_case"]["measurement_spec_ref"]
     payloads["cell_state_evidence_profile"] = {
         "profile_id": "cell-state-profile:run-demo",
         "assay": "scRNA-seq",
-        "measurement_spec_id": measurement["measurement_spec_id"],
-        "measurement_spec_status": measurement["status"],
+        "measurement_spec_id": source_measurement_ref["object_id"],
+        "measurement_spec_status": "candidate",
         "annotation_vocabulary_ref": vocabulary["vocabulary_id"],
         "reference_snapshot_ref": reference["snapshot_id"],
         "n_observations": 100,
@@ -348,8 +348,8 @@ def _prepare(payloads: dict[str, dict]) -> None:
         "evidence_ids": ["evidence:cell-state-demo"],
         "score_state": "shadow",
         "domain_score": None,
-        "measurement_spec_version": measurement["version"],
-        "measurement_spec_sha256": _sha(measurement),
+        "measurement_spec_version": source_measurement_ref["object_version"],
+        "measurement_spec_sha256": "e" * 64,
         "annotation_vocabulary_version": vocabulary["version"],
         "annotation_vocabulary_sha256": _sha(vocabulary),
         "reference_manifest_version": reference["version"],
@@ -395,7 +395,7 @@ def _request(
     return ToolRequestV2(
         request_id="request-p0-03",
         tool_id="P0-03",
-        tool_version="0.4.0",
+        tool_version="0.4.1",
         output_dir=output_dir or (tmp_path / "output"),
         object_inputs=refs,
     )
@@ -573,7 +573,6 @@ def test_identical_inputs_reuse_the_same_bundle(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "role,expected",
     [
-        ("measurement_spec", "measurement_spec_checksum_mismatch"),
         ("annotation_vocabulary", "annotation_vocabulary_checksum_mismatch"),
         ("reference_manifest", "reference_manifest_checksum_mismatch"),
         ("qc_readiness_profile", "cell_state_qc_profile_checksum_mismatch"),
@@ -603,6 +602,136 @@ def test_upstream_object_checksum_bindings_fail_closed(
     result = ToolRegistry.load_default().check_eligibility(request)
     assert not result.eligible
     assert expected in result.reason_codes
+
+
+def test_module_measurement_spec_is_distinct_from_upstream_cell_state_spec(
+    tmp_path: Path,
+) -> None:
+    request = _mutate(
+        _request(tmp_path),
+        "measurement_spec",
+        lambda payload: payload.update(
+            {
+                "measurement_spec_id": "measurement-spec:p0-03-domain",
+                "scientific_question": "Target and regional evidence projection",
+            }
+        ),
+    )
+
+    result = ToolRegistry.load_default().check_eligibility(request)
+
+    assert result.eligible, result.reason_codes
+
+
+def test_generic_conditional_qc_gate_allows_module_specific_evaluation(
+    tmp_path: Path,
+) -> None:
+    request = _mutate(
+        _request(tmp_path),
+        "qc_readiness_profile",
+        lambda payload: payload.update(
+            {"module_eligibility": {"downstream_scientific_modules": "conditional"}}
+        ),
+    )
+    qc_sha = next(
+        ref.sha256 for ref in request.object_inputs if ref.role == "qc_readiness_profile"
+    )
+    request = _mutate(
+        request,
+        "cell_state_evidence_profile",
+        lambda payload: payload.update({"upstream_qc_profile_sha256": qc_sha}),
+    )
+
+    result = ToolRegistry.load_default().check_eligibility(request)
+
+    assert result.eligible, result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "case,expected",
+    [
+        ("assay", "measurement_spec_assay_mismatch"),
+        ("tool", "measurement_spec_tool_not_authorized"),
+        ("analysis_unit", "measurement_spec_biological_unit_mismatch"),
+        ("independence_group", "measurement_spec_biological_unit_mismatch"),
+    ],
+)
+def test_module_measurement_spec_contract_fails_closed(
+    tmp_path: Path, case: str, expected: str
+) -> None:
+    def change(payload: dict) -> None:
+        if case == "assay":
+            payload["assay"] = "snRNA-seq"
+        elif case == "tool":
+            payload["tool_refs"] = []
+        elif case == "analysis_unit":
+            payload["analysis_unit_kind"] = "sample"
+        else:
+            payload["independence_group_kind"] = "donor"
+
+    request = _mutate(_request(tmp_path), "measurement_spec", change)
+
+    result = ToolRegistry.load_default().check_eligibility(request)
+
+    assert not result.eligible
+    assert expected in result.reason_codes
+
+
+def test_cell_state_source_spec_must_belong_to_reference_manifest(
+    tmp_path: Path,
+) -> None:
+    request = _mutate(
+        _request(tmp_path),
+        "reference_manifest",
+        lambda payload: payload.update({"measurement_spec_ids": ["measurement-spec:other"]}),
+    )
+    manifest_sha = next(
+        ref.sha256 for ref in request.object_inputs if ref.role == "reference_manifest"
+    )
+    request = _mutate(
+        request,
+        "cell_state_evidence_profile",
+        lambda payload: payload.update({"reference_manifest_sha256": manifest_sha}),
+    )
+
+    result = ToolRegistry.load_default().check_eligibility(request)
+
+    assert not result.eligible
+    assert "cell_state_measurement_spec_reference_mismatch" in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "explicit,expected_eligible", [("conditional", True), ("ineligible", False)]
+)
+def test_explicit_qc_gate_precedes_generic_gate(
+    tmp_path: Path, explicit: str, expected_eligible: bool
+) -> None:
+    request = _mutate(
+        _request(tmp_path),
+        "qc_readiness_profile",
+        lambda payload: payload.update(
+            {
+                "module_eligibility": {
+                    "downstream_scientific_modules": "eligible",
+                    "P0-03": explicit,
+                }
+            }
+        ),
+    )
+    qc_sha = next(
+        ref.sha256 for ref in request.object_inputs if ref.role == "qc_readiness_profile"
+    )
+    request = _mutate(
+        request,
+        "cell_state_evidence_profile",
+        lambda payload: payload.update({"upstream_qc_profile_sha256": qc_sha}),
+    )
+
+    result = ToolRegistry.load_default().check_eligibility(request)
+
+    assert result.eligible is expected_eligible
+    if not expected_eligible:
+        assert "qc_not_ready_for_target_regional_evidence" in result.reason_codes
 
 
 def test_assessment_spec_binds_exact_shared_state_role_map_bytes(
@@ -884,7 +1013,7 @@ def test_v1_request_is_refused_with_a_typed_failure(tmp_path: Path) -> None:
     request = ToolRequest(
         request_id="request-v1",
         tool_id="P0-03",
-        tool_version="0.4.0",
+        tool_version="0.4.1",
         output_dir=tmp_path,
     )
     eligibility = adapter.check_eligibility(request, spec)
@@ -952,7 +1081,7 @@ def test_sparse_reference_matrix_renders_without_inventing_cells(
         profile=profile,
         output_dir=tmp_path / "sparse-render",
         run_id=run.run_id,
-        tool_version="0.4.0",
+        tool_version="0.4.1",
     )
     assert prepared.payloads["target_regional_reference-fingerprint.png"].startswith(
         b"\x89PNG"
@@ -1021,7 +1150,7 @@ def test_large_visualization_uses_table_fallback_without_losing_results(
         profile=profile,
         output_dir=tmp_path / "oversized-render",
         run_id=run.run_id,
-        tool_version="0.4.0",
+        tool_version="0.4.1",
     )
 
     assert prepared.payloads["target_regional_product-roles.png"].startswith(b"\x89PNG")
@@ -1062,14 +1191,14 @@ def test_svg_render_is_isolated_from_process_global_matplotlib_state(
             profile=profile,
             output_dir=tmp_path / "first-render",
             run_id=run.run_id,
-            tool_version="0.4.0",
+            tool_version="0.4.1",
         )
         matplotlib.rcParams["svg.hashsalt"] = "other-tool-second"
         second = prepare_target_regional_visualizations(
             profile=profile,
             output_dir=tmp_path / "second-render",
             run_id=run.run_id,
-            tool_version="0.4.0",
+            tool_version="0.4.1",
         )
     finally:
         matplotlib.rcParams["svg.hashsalt"] = original_hashsalt


### PR DESCRIPTION
## Biological question

Ensure target/regional measurements are evaluated under the P0-03 domain contract without treating the upstream P0-02 source MeasurementSpec as the same object.

## Data and controls

- Keeps the checksummed ProductCase, P0-02 evidence, QC profile, vocabulary, role map and reference inputs.
- Requires the P0-03 MeasurementSpec to authorize P0-03 and match the declared biological unit.
- Preserves explicit QC eligibility and exact source-object bindings.

## Observed behavior

- Separates the domain MeasurementSpec from the source MeasurementSpec carried by ProductCase.
- Fails closed on assay, tool, biological-unit, reference-manifest or QC authorization mismatch.
- Leaves missing/unknown evidence typed and does not infer values.

## Product-evaluation meaning

This closes an interface-substitution path. It does not change biological roles, thresholds, scores or release status.

## Engineering validation

- P0-03 focused suite plus registry: 50 passed.
- Repository policy and diff hygiene passed.
- No internal path, host, credential or private-resource detail is included.