### PR TITLE
fix: separate P0-04 domain and source contracts

### DIFF
--- a/docs/bridge_spec_v0.1/developmental_compatibility_task_card.md
+++ b/docs/bridge_spec_v0.1/developmental_compatibility_task_card.md
@@ -5,7 +5,10 @@
 | Task ID | `TASK-DEVELOPMENT-v0.1` |
 | Task document version | `0.5` |
 | 日期 | 2026-09-02 |
-| Package version | `P0-04 0.5.0` |
+| Package version | `P0-04 0.5.1` |
+
+ProductCase 与 P0-02 profile 保留 cell-state source MeasurementSpec；P0-04
+使用独立的域 MeasurementSpec 来声明发育指标、assay、工具授权和生物学单位。
 | Runtime / scientific state | `implemented` / `candidate shadow` |
 | 首个实例 | 移植前 hPSC-derived VM floor-plate/mDA 产品 |
 | Current input | checksummed `ProductCase`、`ProductDefinitionCard`、`DevelopmentWindowSpec`、`DevelopmentStateMap`、`MeasurementSpecV2`、`CellStateEvidenceProfileV3`；可选 timepoint series、H5AD 与 `DevelopmentMethodSpec` |

--- a/examples/requests/p0_04_developmental_compatibility.json
+++ b/examples/requests/p0_04_developmental_compatibility.json
@@ -131,5 +131,5 @@
   "random_seed": 17,
   "request_id": "example-p0-04-developmental-compatibility",
   "tool_id": "P0-04",
-  "tool_version": "0.5.0"
+  "tool_version": "0.5.1"
 }

--- a/src/bridge/tool_packages/cards/P0-04.md
+++ b/src/bridge/tool_packages/cards/P0-04.md
@@ -10,7 +10,7 @@ inputs; it does not encode a fetal-age conversion, preferred state or score.
 
 | Field | Value |
 |---|---|
-| Package version | `0.5.0` |
+| Package version | `0.5.1` |
 | Runtime state | `implemented` |
 | Scientific state | `candidate` |
 | Optional | `no` |
@@ -34,13 +34,18 @@ Both modes require one checksummed JSON object for each of the following roles:
 | `product_definition_card` | `product-definition-card/v0.1` | Product scope |
 | `development_window_spec` | `development-window-spec/v0.1` | Reviewed window and composition channel |
 | `development_state_map` | `development-state-map/v0.1` | External state-to-stage and target-related mapping |
-| `measurement_spec` | `measurement-spec/v0.2` | Measurement and independence contract |
+| `measurement_spec` | `measurement-spec/v0.2` | P0-04 metric, assay, tool and independence contract |
 | `cell_state_evidence_profile` | `cell-state-evidence-profile/v0.3` | Current P0-02 composition and provenance |
 | `qc_readiness_profile` | `qc-readiness-profile/v0.2` | P0-01 readiness and selected view |
 | `biological_unit_manifest` | `biological-unit-manifest/v0.1` | Analysis and independence units |
 | `biological_unit_assignment` | `biological-unit-assignment/v0.1` | Observation-to-unit assignment |
 | `annotation_vocabulary` | `annotation-vocabulary/v0.1` | State identity |
 | `reference_manifest` | `reference-manifest/v0.1` | Checksummed reference and program assets |
+
+ProductCase and the P0-02 profile bind the upstream cell-state source
+MeasurementSpec, whose ID must be present in the reference manifest. The
+separate P0-04 MeasurementSpec must authorize P0-04 and match the case assay,
+product applicability, analysis unit and independence group.
 
 `development_timepoint_series` is optional. Aggregation mode uses no H5AD and
 returns the two externally defined stage-composition denominators.

--- a/src/bridge/tool_packages/p0_04_developmental_compatibility/README.md
+++ b/src/bridge/tool_packages/p0_04_developmental_compatibility/README.md
@@ -11,6 +11,10 @@ target-related `earlier`, `within_window`, `later`, `branch_shift` and
 executes selected reference, ordinal, program and bootstrap methods from a
 versioned `DevelopmentMethodSpec`.
 
+The ProductCase and P0-02 profile keep their cell-state source MeasurementSpec.
+P0-04 receives a separate domain MeasurementSpec that owns developmental metric
+projection, assay, tool authorization and biological-unit semantics.
+
 The ordinal method is an uncalibrated baseline and runs only when the same
 checksummed method spec supplies a reviewed, passed source-group-held-out
 evidence receipt bound to every selected profile and at least two sources.

--- a/src/bridge/tool_packages/p0_04_developmental_compatibility/adapter.py
+++ b/src/bridge/tool_packages/p0_04_developmental_compatibility/adapter.py
@@ -12,6 +12,7 @@ from bridge.tool_packages._configurable_contracts import (
     ProductDefinitionCard,
     VersionedObjectRef,
     profile_lineage_reasons,
+    qc_allows_module,
 )
 from bridge.tool_packages._structured_runtime import (
     LoadedInputs,
@@ -64,7 +65,6 @@ from bridge.toolkit.contracts import (
     ImplementationState,
     MeasurementSpecV2,
     QCReadinessProfileV2,
-    ReadinessState,
     ReferenceManifest,
     StructuredInputRef,
     ToolPackageSpecV2,
@@ -578,7 +578,7 @@ def _binding_reasons(
     reasons = profile_lineage_reasons(
         product_case=product_case,
         cell_state_profile=profile,
-        measurement_spec=measurement_spec,
+        measurement_spec=None,
         qc_profile=qc_profile,
         biological_unit_manifest=biological_unit_manifest,
         biological_unit_assignment_artifact=biological_unit_assignment,
@@ -601,6 +601,15 @@ def _binding_reasons(
         reasons.append("window_assay_not_supported")
     if measurement_spec.assay != product_case.assay:
         reasons.append("measurement_spec_assay_mismatch")
+    if "P0-04" not in measurement_spec.tool_refs:
+        reasons.append("measurement_spec_tool_not_authorized")
+    if (
+        measurement_spec.analysis_unit_kind
+        != biological_unit_manifest.analysis_unit_kind
+        or measurement_spec.independence_group_kind
+        != biological_unit_manifest.independence_group_kind
+    ):
+        reasons.append("measurement_spec_biological_unit_mismatch")
     if (
         measurement_spec.applicable_product_cards
         and product_definition.product_definition_id
@@ -612,15 +621,7 @@ def _binding_reasons(
         reasons.append("cell_state_assay_binding_mismatch")
     if qc_profile.assay != product_case.assay:
         reasons.append("qc_profile_assay_mismatch")
-    if (
-        qc_profile.readiness_state
-        in {
-            ReadinessState.BLOCKED,
-            ReadinessState.NOT_ASSESSED,
-            ReadinessState.NOT_APPLICABLE,
-        }
-        or qc_profile.module_eligibility.get("P0-04") != "eligible"
-    ):
+    if not qc_allows_module(qc_profile, "P0-04"):
         reasons.append("qc_not_ready_for_developmental_compatibility")
     if profile.composition.state not in COMPOSITION_STATES:
         reasons.append("cell_state_composition_state_invalid")
@@ -646,8 +647,8 @@ def _binding_reasons(
         != input_sha256_by_role["reference_manifest"]
     ):
         reasons.append("reference_manifest_checksum_mismatch")
-    if measurement_spec.measurement_spec_id not in reference_manifest.measurement_spec_ids:
-        reasons.append("reference_manifest_measurement_spec_mismatch")
+    if profile.measurement_spec_id not in reference_manifest.measurement_spec_ids:
+        reasons.append("cell_state_measurement_spec_reference_mismatch")
     if measurement_spec.reference_refs and not {
         reference_manifest.snapshot_id,
         f"{reference_manifest.snapshot_id}@{reference_manifest.version}",

--- a/src/bridge/tool_packages/specs/p0_04.yaml
+++ b/src/bridge/tool_packages/specs/p0_04.yaml
@@ -1,6 +1,6 @@
 tool_id: P0-04
 name: Developmental Compatibility
-version: 0.5.0
+version: 0.5.1
 summary: Aggregate reviewed developmental roles, reference evidence, uncertainty, and ordered sampling-point summaries.
 implementation_state: implemented
 scientific_status: candidate

--- a/tests/test_p0_04_developmental_compatibility.py
+++ b/tests/test_p0_04_developmental_compatibility.py
@@ -81,7 +81,7 @@ def _base_payloads() -> dict[str, dict]:
             "product_definition_ref": product_ref,
             "source_unit_kind": "sample",
             "sample_or_preparation_ref": _ref("sample:demo"),
-            "measurement_spec_ref": _ref("measurement-spec:development"),
+            "measurement_spec_ref": _ref("measurement-spec:cell-state-source"),
             "assay": "scRNA-seq",
             "provenance_refs": [_ref("source:fully-synthetic")],
             "created_at": "2026-08-25T00:00:00Z",
@@ -219,7 +219,7 @@ def _base_payloads() -> dict[str, dict]:
             "vocabulary_sha256": "0" * 64,
             "marker_program_file": "marker_programs.json",
             "marker_program_sha256": "d" * 64,
-            "measurement_spec_ids": ["measurement-spec:development"],
+            "measurement_spec_ids": ["measurement-spec:cell-state-source"],
             "profiles": [],
             "prohibited_source_families": [],
         },
@@ -386,12 +386,12 @@ def _prepare(
     vocabulary = payloads["annotation_vocabulary"]
     reference = payloads["reference_manifest"]
     reference["vocabulary_sha256"] = _sha(vocabulary)
-    measurement = payloads["measurement_spec"]
+    source_measurement_ref = payloads["product_case"]["measurement_spec_ref"]
     payloads["cell_state_evidence_profile"] = {
         "profile_id": "cell-state-profile:run-demo",
         "assay": "scRNA-seq",
-        "measurement_spec_id": measurement["measurement_spec_id"],
-        "measurement_spec_status": measurement["status"],
+        "measurement_spec_id": source_measurement_ref["object_id"],
+        "measurement_spec_status": "candidate",
         "annotation_vocabulary_ref": vocabulary["vocabulary_id"],
         "reference_snapshot_ref": reference["snapshot_id"],
         "n_observations": n_observations,
@@ -424,8 +424,8 @@ def _prepare(
         "evidence_ids": ["evidence:cell-state-demo"],
         "score_state": "shadow",
         "domain_score": None,
-        "measurement_spec_version": measurement["version"],
-        "measurement_spec_sha256": _sha(measurement),
+        "measurement_spec_version": source_measurement_ref["object_version"],
+        "measurement_spec_sha256": "e" * 64,
         "annotation_vocabulary_version": vocabulary["version"],
         "annotation_vocabulary_sha256": _sha(vocabulary),
         "reference_manifest_version": reference["version"],
@@ -513,7 +513,7 @@ def _request(
     return ToolRequestV2(
         request_id="request-p0-04",
         tool_id="P0-04",
-        tool_version="0.5.0",
+        tool_version="0.5.1",
         output_dir=output_dir or (tmp_path / "output"),
         object_inputs=refs,
     )
@@ -542,7 +542,7 @@ def _mutate(request: ToolRequestV2, role: str, change) -> ToolRequestV2:
 def test_registry_exposes_current_traceable_contract() -> None:
     registry = ToolRegistry.load_default()
     spec = registry.describe("P0-04")
-    assert spec.version == "0.5.0"
+    assert spec.version == "0.5.1"
     assert spec.implementation_state.value == "implemented"
     assert RESULT_SCHEMA_REF.endswith("/v0.3")
     assert ROLE_SCHEMAS["cell_state_evidence_profile"].endswith("/v0.3")
@@ -624,6 +624,126 @@ def test_required_lineage_and_checksum_fail_closed(tmp_path: Path) -> None:
     eligibility = registry.check_eligibility(invalid)
     assert not eligibility.eligible
     assert "structured_input_checksum_mismatch" in eligibility.reason_codes
+
+
+def test_module_measurement_spec_is_distinct_from_upstream_cell_state_spec(
+    tmp_path: Path,
+) -> None:
+    request = _mutate(
+        _request(tmp_path),
+        "measurement_spec",
+        lambda payload: payload.update(
+            {
+                "measurement_spec_id": "measurement-spec:p0-04-domain",
+                "scientific_question": "Developmental compatibility projection",
+            }
+        ),
+    )
+
+    result = ToolRegistry.load_default().check_eligibility(request)
+
+    assert result.eligible, result.reason_codes
+
+
+def test_generic_conditional_qc_gate_allows_developmental_evaluation(
+    tmp_path: Path,
+) -> None:
+    request = _mutate(
+        _request(tmp_path),
+        "qc_readiness_profile",
+        lambda payload: payload.update(
+            {"module_eligibility": {"downstream_scientific_modules": "conditional"}}
+        ),
+    )
+    qc_sha = next(
+        ref.sha256 for ref in request.object_inputs if ref.role == "qc_readiness_profile"
+    )
+    request = _mutate(
+        request,
+        "cell_state_evidence_profile",
+        lambda payload: payload.update({"upstream_qc_profile_sha256": qc_sha}),
+    )
+
+    result = ToolRegistry.load_default().check_eligibility(request)
+
+    assert result.eligible, result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "case,expected",
+    [
+        ("assay", "measurement_spec_assay_mismatch"),
+        ("tool", "measurement_spec_tool_not_authorized"),
+        ("analysis_unit", "measurement_spec_biological_unit_mismatch"),
+        ("independence_group", "measurement_spec_biological_unit_mismatch"),
+    ],
+)
+def test_module_measurement_spec_contract_fails_closed(
+    tmp_path: Path, case: str, expected: str
+) -> None:
+    def change(payload: dict) -> None:
+        if case == "assay":
+            payload["assay"] = "snRNA-seq"
+        elif case == "tool":
+            payload["tool_refs"] = []
+        elif case == "analysis_unit":
+            payload["analysis_unit_kind"] = "sample"
+        else:
+            payload["independence_group_kind"] = "sample"
+
+    request = _mutate(_request(tmp_path), "measurement_spec", change)
+
+    result = ToolRegistry.load_default().check_eligibility(request)
+
+    assert not result.eligible
+    assert expected in result.reason_codes
+
+
+def test_cell_state_source_spec_must_belong_to_reference_manifest(
+    tmp_path: Path,
+) -> None:
+    request = _mutate(
+        _request(tmp_path),
+        "reference_manifest",
+        lambda payload: payload.update({"measurement_spec_ids": ["measurement-spec:other"]}),
+    )
+    manifest_sha = next(
+        ref.sha256 for ref in request.object_inputs if ref.role == "reference_manifest"
+    )
+    request = _mutate(
+        request,
+        "cell_state_evidence_profile",
+        lambda payload: payload.update({"reference_manifest_sha256": manifest_sha}),
+    )
+
+    result = ToolRegistry.load_default().check_eligibility(request)
+
+    assert not result.eligible
+    assert "cell_state_measurement_spec_reference_mismatch" in result.reason_codes
+
+
+def test_explicit_conditional_qc_gate_allows_developmental_evaluation(
+    tmp_path: Path,
+) -> None:
+    request = _mutate(
+        _request(tmp_path),
+        "qc_readiness_profile",
+        lambda payload: payload.update(
+            {"module_eligibility": {"P0-04": "conditional"}}
+        ),
+    )
+    qc_sha = next(
+        ref.sha256 for ref in request.object_inputs if ref.role == "qc_readiness_profile"
+    )
+    request = _mutate(
+        request,
+        "cell_state_evidence_profile",
+        lambda payload: payload.update({"upstream_qc_profile_sha256": qc_sha}),
+    )
+
+    result = ToolRegistry.load_default().check_eligibility(request)
+
+    assert result.eligible, result.reason_codes
 
 
 def test_unconfirmed_window_and_unavailable_upstream_are_typed(
@@ -725,7 +845,7 @@ def test_v1_request_is_typed_refusal(tmp_path: Path) -> None:
     request = ToolRequest(
         request_id="legacy-request",
         tool_id="P0-04",
-        tool_version="0.5.0",
+        tool_version="0.5.1",
         output_dir=tmp_path.resolve(),
     )
     eligibility = adapter.check_eligibility(request, spec)


### PR DESCRIPTION
## Biological question

Ensure developmental measurements are evaluated under a P0-04 domain MeasurementSpec without substituting the upstream P0-02 cell-state source contract.

## Data and controls

- Keeps checksummed ProductCase, product definition, developmental window/state map, P0-02 evidence, QC, biological-unit, vocabulary and reference inputs.
- Requires the P0-04 MeasurementSpec to authorize P0-04 and match assay, product applicability and biological units.
- Requires the P0-02 source MeasurementSpec identity to remain present in the reference manifest.

## Observed behavior

- Separates the domain and source MeasurementSpecs.
- Accepts explicit eligible or conditional QC authorization.
- Fails closed on assay, tool, biological-unit, lineage, reference or QC authorization mismatch.

## Product-evaluation meaning

This closes an interface-substitution path. It does not add developmental thresholds, stage calls, scores or release claims.

## Engineering validation

- P0-04 focused suite plus registry: 39 passed.
- Repository policy and diff hygiene passed.
- No internal path, host, credential or private-resource detail is included.
