### PR TITLE
feat: close P0-09 canonical sufficiency ingestion

### DIFF
--- a/docs/bridge_spec_v0.1/evidence_compiler_task_card.md
+++ b/docs/bridge_spec_v0.1/evidence_compiler_task_card.md
@@ -3,7 +3,7 @@
 | 字段 | 内容 |
 |---|---|
 | Task ID | `TASK-EVIDENCE-COMPILER` |
-| Tool ID / version | `P0-09` / `0.3.0` |
+| Tool ID / version | `P0-09` / `0.4.0` |
 | Date | 2026-08-13 |
 | Analysis unit | `metric x claim target x biological context x MeasurementSpec` |
 | Runtime state | `implemented` |
@@ -24,15 +24,18 @@ P0-09 读取已经完成且版本化的产品证据，回答：哪些原子记�
 |---|---:|---|---|
 | `compilation_bundle` | 1 | `evidence-compilation-bundle/v0.1` | Case/Comparison scope、候选项、缺失观察、对象目录和可选历史 |
 | `evidence_sufficiency_profile` | Case 1–5；Comparison 2–25 | `evidence-sufficiency-profile/v0.1` 或 `v0.2` | P0-08 的产品、域、MeasurementSpec、sufficiency 和 provenance |
+| `evidence_sufficiency_run_result` | Case 1；Comparison 2–5 | `evidence-sufficiency-run-result/v0.2` | P0-08 canonical wrapper、source bindings、profiles、case summary 与 gate trace |
 | `evidence_family_registry` | 1 | `evidence-family-registry/v0.1` | family 类型、channel role、独立性范围和审核状态 |
 | `claim_registry` | 1 | `claim-registry/v0.1` | Claim、允许方向和 requirement template |
 | `reconciliation_spec_registry` | 1 | `reconciliation-spec-registry/v0.1` | required/optional channel、独立 family 数和冲突规则 |
-| `base_graph_manifest` / `base_evidence_record_set` / `base_evidence_requirement_set` | Case 有 base 时各 1，否则 0 | Case manifest / 两类 fact set | 三者与 `AppendGraphRef` 的 input ID 逐一绑定；Comparison 禁止 |
+| `base_graph_manifest` / `base_evidence_record_set` / `base_evidence_requirement_set` | Case 或 Comparison append 有对应 base 时各 1，否则 0 | 同类 graph manifest / 两类 fact set | 三者与 `AppendGraphRef` 的 input ID 逐一绑定；initial 模式禁止 |
 | `source_case_graph_manifest` / `source_case_evidence_record_set` | Comparison 每个 Case 各 1 | Case manifest / EvidenceRecordSet | 与每个 `BoundCaseGraphRef` input ID 严格双射；Case 禁止 |
+
+四个 direct-profile 模式保留兼容；四个对应 `_v2` 模式只接收 canonical run-result。两类输入不得混用。canonical-run 模式中，bundle 的 `sufficiency_profile_input_id` 指向 run-result input ID；adapter 仅按 wrapper、ProductCase 和 domain 唯一定位内嵌 profile。MeasurementSpec、MeasurementResult、Claim、source record 和 family 的逐条漂移由 compiler 隔离为 partial，不升级为整次技术失败。重复 result ID/version、case set 不闭合或 profile 无法唯一解析仍 fail closed。
 
 `assets=[]`、顶层 `measurement_spec_ref=null`、`parameters={}`。`random_seed` 仅为共享 envelope 兼容而保留，算法不使用随机数。输入期间发生任何字节变化都使整次运行失败。
 
-Case bundle 只拥有一个 ProductCase 及其记录历史；有历史时必须同时提供内容寻址的 base manifest、record set 和 requirement set，且三类事实与 bundle 历史完全一致。Comparison bundle 只引用至少两个 Case graph，不允许 base/prior/owned records，不复制案例值、区间或私有属性。每个 source manifest 会在原始目录中通过七查询层的 `open()` 完整验证五个 authoritative artifacts，再核对 raw manifest SHA、record-set SHA、确定性 graph ID、graph version 和 ProductCase。所有 Claim 映射、ProductCase、MeasurementSpec、EvidenceFamily 和 P0-08 profile 绑定必须显式声明，不能由 Agent 推断。
+Case bundle 只拥有一个 ProductCase 及其记录历史；有历史时必须同时提供内容寻址的 base manifest、record set 和 requirement set，且三类事实与 bundle 历史完全一致。Comparison bundle 只引用至少两个 Case graph，不拥有 Case candidate/missing/history；append 时可显式绑定一个既有 Comparison base graph，不复制案例值、区间或私有属性。每个 source manifest 会在原始目录中通过七查询层的 `open()` 完整验证五个 authoritative artifacts，再核对 raw manifest SHA、record-set SHA、确定性 graph ID、graph version 和 ProductCase。所有 Claim 映射、ProductCase、MeasurementSpec、EvidenceFamily 和 P0-08 profile 绑定必须显式声明，不能由 Agent 推断。
 
 ## 3. 原子 EvidenceRecord 与追加式修正
 

--- a/docs/tool-packages.md
+++ b/docs/tool-packages.md
@@ -147,9 +147,9 @@ scientific methods.
 | Purpose | Compile immutable evidence, explicit missing requirements and versioned conflicts into a bounded evidence graph. [Scientific task card](bridge_spec_v0.1/evidence_compiler_task_card.md). |
 | Executable implementation | Deterministic compiler/reconciler, append-only versioning, graph reconstruction and seven named read-only queries; no arbitrary writes or Cypher. |
 | Software | [NetworkX](https://networkx.org/documentation/stable/) for reconstruction/invariant checks and [PyArrow/Parquet](https://arrow.apache.org/docs/python/) for graph facts, plus the shared runtime. |
-| Input → output | Compilation bundle, P0-08 v0.1/v0.2 profiles and EvidenceFamily, Claim and Reconciliation registries → record sets, JSON/Parquet graph facts, three typed figures with complete TSV fallbacks, Cytoscape elements and manifests. [Tool Card](../src/bridge/tool_packages/cards/P0-09.md). |
+| Input → output | Compilation bundle, either direct P0-08 v0.1/v0.2 profiles or canonical P0-08 v0.2 run results, and EvidenceFamily, Claim and Reconciliation registries → record sets, JSON/Parquet graph facts, three typed figures with complete TSV fallbacks, Cytoscape elements and manifests. [Tool Card](../src/bridge/tool_packages/cards/P0-09.md). |
 | Call | Shared CLI/SDK with `tool_id=P0-09`; start from the [request example](../examples/requests/p0_09_evidence_compiler.json). |
-| Current evidence / status | Implemented candidate. Missing evidence remains a requirement; record/family counts are not independent evidence; shadow input is not promoted. P0-08 v0.2 still lacks versioned family identity, so formal compilation remains conservatively unavailable. |
+| Current evidence / status | Implemented candidate. Canonical run-result ingestion supports case/comparison initial and append modes; duplicate run identity fails closed, while record-level provenance drift is isolated as partial. Missing evidence remains a requirement; record/family counts are not independent evidence; shadow input is not promoted. P0-08 v0.2 still lacks versioned family identity, so formal compilation remains conservatively unavailable. [Validation record](validation/p0_09_sufficiency_v2_ingestion_v0.4.md). |
 
 <a id="p0-10"></a>
 ## P0-10 Claim Verifier

--- a/docs/validation/p0_09_sufficiency_v2_ingestion_v0.4.md
+++ b/docs/validation/p0_09_sufficiency_v2_ingestion_v0.4.md
@@ -1,0 +1,73 @@
+# P0-09 canonical sufficiency ingestion validation
+
+Date: 2026-09-05
+Package: `P0-09 Evidence Compiler & Reconciler` v0.4.0
+Prerequisite: P0-08 v0.5 case-bound result contract
+
+## Scope
+
+This record validates the P0-09 interface that consumes canonical
+`EvidenceSufficiencyRunResultV2` objects without changing the P0-09 result
+Schema. Direct v0.1/v0.2 profile inputs remain supported.
+
+The executable matrix covers:
+
+| Scope | Direct profile mode | Canonical run-result mode |
+|---|---|---|
+| Case, initial | `case_initial` | `case_initial_v2` |
+| Case, append | `case_append` | `case_append_v2` |
+| Comparison, initial | `comparison_initial` | `comparison_initial_v2` |
+| Comparison, append | `comparison_append` | `comparison_append_v2` |
+
+## Verified behavior
+
+- Canonical mode accepts one P0-08 v0.2 run for a Case and two to five
+  case-distinct runs for a Comparison.
+- The complete P0-08 wrapper remains a checksummed semantic input. Each emitted
+  EvidenceRecord cites the exact embedded profile version.
+- The adapter resolves an embedded profile by request binding, ProductCase and
+  domain. MeasurementSpec, MeasurementResult, Claim, source-record and family
+  checks remain compiler-owned record checks.
+- A Schema-valid record with drift is rejected into sanitized metadata while
+  valid siblings are published as a `partial` run.
+- A missing-only Case creates open EvidenceRequirements, emits no EvidenceRecord
+  and never substitutes a numeric zero.
+- Duplicate `result_id` plus `result_version` identities, mixed direct/run
+  modes, case-set mismatch, checksum mismatch and ambiguous profile routing fail
+  closed before artifact publication.
+- The canonical fixture includes the ProductCase source binding emitted by the
+  current P0-08 producer path.
+- P0-08 family bindings remain ID-only. P0-09 therefore continues to reject
+  formal evidence with `sufficiency_profile_version_binding_unavailable`.
+
+## Executed checks
+
+An isolated Linux source environment ran:
+
+- `tests/test_p0_09_evidence_compiler.py`
+- `tests/test_registry.py`
+
+Result: **218 passed**.
+
+The focused regression set additionally exercised canonical Case initial,
+canonical Comparison initial, duplicate run identity, missing-only requirements,
+mixed-mode refusal, record-level MeasurementResult drift, and dangling
+Comparison provenance. Result: **6 passed, 212 deselected**.
+
+Repository policy, shared contract tests, diff hygiene and publication-boundary
+scans are recorded in the associated change history and continuous integration.
+
+## Provenance design basis
+
+The separation between run-wrapper identity and record-level derivation follows
+the explicit activity/entity linkage in
+[W3C PROV-O](https://www.w3.org/TR/prov-o/) and the unique run, tool version,
+consumed object and generated result conventions in
+[Workflow Run RO-Crate Process Run 0.5](https://www.researchobject.org/workflow-run-crate/profiles/0.5/process_run_crate/).
+
+## Scientific boundary
+
+This is engineering validation of deterministic ingestion, provenance,
+failure isolation and artifact behavior. It does not establish biological
+truth, evidence sufficiency, product superiority, potency, safety, efficacy or
+release eligibility. P0-09 remains `candidate`; no domain score is created.

--- a/examples/requests/p0_09_evidence_compiler.json
+++ b/examples/requests/p0_09_evidence_compiler.json
@@ -12,12 +12,12 @@
       "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     },
     {
-      "input_id": "target-profile",
+      "input_id": "sufficiency-run",
       "media_type": "application/json",
-      "object_version": "0.1.0",
-      "path": "/absolute/path/to/evidence_sufficiency_profile.json",
-      "role": "evidence_sufficiency_profile",
-      "schema_ref": "bridge://schemas/evidence-sufficiency-profile/v0.1",
+      "object_version": "0.2.0",
+      "path": "/absolute/path/to/evidence_sufficiency_run_result.json",
+      "role": "evidence_sufficiency_run_result",
+      "schema_ref": "bridge://schemas/evidence-sufficiency-run-result/v0.2",
       "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     },
     {
@@ -53,5 +53,5 @@
   "random_seed": 0,
   "request_id": "example-p0-09-documentation-only",
   "tool_id": "P0-09",
-  "tool_version": "0.3.0"
+  "tool_version": "0.4.0"
 }

--- a/src/bridge/tool_packages/_input_contracts.py
+++ b/src/bridge/tool_packages/_input_contracts.py
@@ -215,6 +215,115 @@ def _p006_base_roles(
     )
 
 
+def _p009_mode(
+    mode_id: str,
+    *,
+    comparison: bool,
+    append: bool,
+    canonical_run: bool,
+) -> ObjectInputModeContract:
+    if canonical_run:
+        sufficiency = _role(
+            "evidence_sufficiency_run_result",
+            "bridge://schemas/evidence-sufficiency-run-result/v0.2",
+            V02,
+            2 if comparison else 1,
+            5 if comparison else 1,
+        )
+    else:
+        sufficiency = _role(
+            "evidence_sufficiency_profile",
+            (
+                "bridge://schemas/evidence-sufficiency-profile/v0.1",
+                "bridge://schemas/evidence-sufficiency-profile/v0.2",
+            ),
+            (V01, V02),
+            2 if comparison else 1,
+            25 if comparison else 5,
+        )
+    roles = [
+        _role(
+            "compilation_bundle",
+            "bridge://schemas/evidence-compilation-bundle/v0.1",
+            V01,
+            1,
+            1,
+        ),
+        sufficiency,
+        _role(
+            "evidence_family_registry",
+            "bridge://schemas/evidence-family-registry/v0.1",
+            V01,
+            1,
+            1,
+        ),
+        _role(
+            "claim_registry",
+            "bridge://schemas/claim-registry/v0.1",
+            V01,
+            1,
+            1,
+        ),
+        _role(
+            "reconciliation_spec_registry",
+            "bridge://schemas/reconciliation-spec-registry/v0.1",
+            V01,
+            1,
+            1,
+        ),
+    ]
+    if append:
+        roles.extend(
+            [
+                _role(
+                    "base_graph_manifest",
+                    (
+                        "bridge://schemas/comparison-evidence-graph-manifest/v0.1"
+                        if comparison
+                        else "bridge://schemas/case-evidence-graph-manifest/v0.1"
+                    ),
+                    None,
+                    1,
+                    1,
+                ),
+                _role(
+                    "base_evidence_record_set",
+                    "bridge://schemas/evidence-record-set/v0.1",
+                    V01,
+                    1,
+                    1,
+                ),
+                _role(
+                    "base_evidence_requirement_set",
+                    "bridge://schemas/evidence-requirement-set/v0.1",
+                    V01,
+                    1,
+                    1,
+                ),
+            ]
+        )
+    if comparison:
+        roles.extend(
+            [
+                _role(
+                    "source_case_graph_manifest",
+                    "bridge://schemas/case-evidence-graph-manifest/v0.1",
+                    None,
+                    2,
+                    5,
+                ),
+                _role(
+                    "source_case_evidence_record_set",
+                    "bridge://schemas/evidence-record-set/v0.1",
+                    V01,
+                    2,
+                    5,
+                ),
+            ]
+        )
+    return _mode(mode_id, *roles)
+
+
 INPUT_CONTRACTS: dict[str, ToolInputContract] = {
     "P0-01": ToolInputContract(
         tool_id="P0-01",
@@ -785,217 +894,53 @@ INPUT_CONTRACTS: dict[str, ToolInputContract] = {
         parameters_allowed=False,
         random_seed_policy="any_integer",
         object_input_modes=[
-            _mode(
+            _p009_mode(
                 "case_initial",
-                _role(
-                    "compilation_bundle",
-                    "bridge://schemas/evidence-compilation-bundle/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "evidence_sufficiency_profile",
-                    "bridge://schemas/evidence-sufficiency-profile/v0.1",
-                    V01,
-                    1,
-                    5,
-                ),
-                _role(
-                    "evidence_family_registry",
-                    "bridge://schemas/evidence-family-registry/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "claim_registry", "bridge://schemas/claim-registry/v0.1", V01, 1, 1
-                ),
-                _role(
-                    "reconciliation_spec_registry",
-                    "bridge://schemas/reconciliation-spec-registry/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
+                comparison=False,
+                append=False,
+                canonical_run=False,
             ),
-            _mode(
+            _p009_mode(
                 "case_append",
-                _role(
-                    "compilation_bundle",
-                    "bridge://schemas/evidence-compilation-bundle/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "evidence_sufficiency_profile",
-                    "bridge://schemas/evidence-sufficiency-profile/v0.1",
-                    V01,
-                    1,
-                    5,
-                ),
-                _role(
-                    "evidence_family_registry",
-                    "bridge://schemas/evidence-family-registry/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "claim_registry", "bridge://schemas/claim-registry/v0.1", V01, 1, 1
-                ),
-                _role(
-                    "reconciliation_spec_registry",
-                    "bridge://schemas/reconciliation-spec-registry/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "base_graph_manifest",
-                    (
-                        "bridge://schemas/case-evidence-graph-manifest/v0.1",
-                        "bridge://schemas/comparison-evidence-graph-manifest/v0.1",
-                    ),
-                    None,
-                    1,
-                    1,
-                ),
-                _role(
-                    "base_evidence_record_set",
-                    "bridge://schemas/evidence-record-set/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "base_evidence_requirement_set",
-                    "bridge://schemas/evidence-requirement-set/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
+                comparison=False,
+                append=True,
+                canonical_run=False,
             ),
-            _mode(
+            _p009_mode(
                 "comparison_initial",
-                _role(
-                    "compilation_bundle",
-                    "bridge://schemas/evidence-compilation-bundle/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "evidence_sufficiency_profile",
-                    "bridge://schemas/evidence-sufficiency-profile/v0.1",
-                    V01,
-                    2,
-                    25,
-                ),
-                _role(
-                    "evidence_family_registry",
-                    "bridge://schemas/evidence-family-registry/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "claim_registry", "bridge://schemas/claim-registry/v0.1", V01, 1, 1
-                ),
-                _role(
-                    "reconciliation_spec_registry",
-                    "bridge://schemas/reconciliation-spec-registry/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "source_case_graph_manifest",
-                    "bridge://schemas/case-evidence-graph-manifest/v0.1",
-                    None,
-                    2,
-                    5,
-                ),
-                _role(
-                    "source_case_evidence_record_set",
-                    "bridge://schemas/evidence-record-set/v0.1",
-                    V01,
-                    2,
-                    5,
-                ),
+                comparison=True,
+                append=False,
+                canonical_run=False,
             ),
-            _mode(
+            _p009_mode(
                 "comparison_append",
-                _role(
-                    "compilation_bundle",
-                    "bridge://schemas/evidence-compilation-bundle/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "evidence_sufficiency_profile",
-                    "bridge://schemas/evidence-sufficiency-profile/v0.1",
-                    V01,
-                    2,
-                    25,
-                ),
-                _role(
-                    "evidence_family_registry",
-                    "bridge://schemas/evidence-family-registry/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "claim_registry", "bridge://schemas/claim-registry/v0.1", V01, 1, 1
-                ),
-                _role(
-                    "reconciliation_spec_registry",
-                    "bridge://schemas/reconciliation-spec-registry/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "base_graph_manifest",
-                    (
-                        "bridge://schemas/case-evidence-graph-manifest/v0.1",
-                        "bridge://schemas/comparison-evidence-graph-manifest/v0.1",
-                    ),
-                    None,
-                    1,
-                    1,
-                ),
-                _role(
-                    "base_evidence_record_set",
-                    "bridge://schemas/evidence-record-set/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "base_evidence_requirement_set",
-                    "bridge://schemas/evidence-requirement-set/v0.1",
-                    V01,
-                    1,
-                    1,
-                ),
-                _role(
-                    "source_case_graph_manifest",
-                    "bridge://schemas/case-evidence-graph-manifest/v0.1",
-                    None,
-                    2,
-                    5,
-                ),
-                _role(
-                    "source_case_evidence_record_set",
-                    "bridge://schemas/evidence-record-set/v0.1",
-                    V01,
-                    2,
-                    5,
-                ),
+                comparison=True,
+                append=True,
+                canonical_run=False,
+            ),
+            _p009_mode(
+                "case_initial_v2",
+                comparison=False,
+                append=False,
+                canonical_run=True,
+            ),
+            _p009_mode(
+                "case_append_v2",
+                comparison=False,
+                append=True,
+                canonical_run=True,
+            ),
+            _p009_mode(
+                "comparison_initial_v2",
+                comparison=True,
+                append=False,
+                canonical_run=True,
+            ),
+            _p009_mode(
+                "comparison_append_v2",
+                comparison=True,
+                append=True,
+                canonical_run=True,
             ),
         ],
     ),

--- a/src/bridge/tool_packages/cards/P0-09.md
+++ b/src/bridge/tool_packages/cards/P0-09.md
@@ -8,7 +8,7 @@ Given already-computed, versioned product evidence, which atomic records support
 
 | Field | Value |
 |---|---|
-| Package version | `0.3.0` |
+| Package version | `0.4.0` |
 | Runtime state | `implemented` |
 | Scientific state | `candidate` |
 | EnvironmentSpec | `ENV-EVIDENCE-v0.2` (`health_check_passed`) |
@@ -28,14 +28,17 @@ Every object is an immutable local `application/json` file referenced by `Struct
 |---|---:|---|---|
 | `compilation_bundle` | exactly 1 | `evidence-compilation-bundle/v0.1` | Case or Comparison scope, object catalog, candidate/missing items, optional prior history |
 | `evidence_sufficiency_profile` | Case 1–5; Comparison 2–25 | `evidence-sufficiency-profile/v0.1` or `v0.2` | ProductCase, domain, MeasurementSpec, sufficiency state and provenance |
+| `evidence_sufficiency_run_result` | Case exactly 1; Comparison 2–5 | `evidence-sufficiency-run-result/v0.2` | Canonical P0-08 wrapper containing one to five versioned profiles and path-free source bindings |
 | `evidence_family_registry` | exactly 1 | `evidence-family-registry/v0.1` | Family version, channel role, independence scope, review state |
 | `claim_registry` | exactly 1 | `claim-registry/v0.1` | Claim version, domain, allowed relations and requirement templates |
 | `reconciliation_spec_registry` | exactly 1 | `reconciliation-spec-registry/v0.1` | Frozen channel/minimum/conflict rules; no weights or generic expressions |
-| `base_graph_manifest` | exactly 1 iff Case `base_graph_ref` exists | Case graph manifest | Exact prior graph manifest; forbidden otherwise |
-| `base_evidence_record_set` | exactly 1 iff Case `base_graph_ref` exists | `evidence-record-set/v0.1` | Complete prior EvidenceRecord history named by the base manifest |
-| `base_evidence_requirement_set` | exactly 1 iff Case `base_graph_ref` exists | `evidence-requirement-set/v0.1` | Complete prior EvidenceRequirement history named by the base manifest |
+| `base_graph_manifest` | exactly 1 iff the matching Case or Comparison `base_graph_ref` exists | matching Case or Comparison graph manifest | Exact prior graph manifest; forbidden otherwise |
+| `base_evidence_record_set` | exactly 1 iff the matching `base_graph_ref` exists | `evidence-record-set/v0.1` | Complete prior EvidenceRecord history named by the base manifest |
+| `base_evidence_requirement_set` | exactly 1 iff the matching `base_graph_ref` exists | `evidence-requirement-set/v0.1` | Complete prior EvidenceRequirement history named by the base manifest |
 | `source_case_graph_manifest` | exactly 1 per Comparison case ref | Case graph manifest | Content-addressed source Case graph; forbidden for Case compilation |
 | `source_case_evidence_record_set` | exactly 1 per Comparison case ref | `evidence-record-set/v0.1` | Exact source facts named by its paired manifest |
+
+Direct-profile modes (`case_initial`, `case_append`, `comparison_initial`, `comparison_append`) accept v0.1/v0.2 profiles. Canonical-run modes use the same names with `_v2` and accept only run-result v0.2 objects. The two roles cannot be mixed. In a canonical-run mode, `sufficiency_profile_input_id` names the run-result input; P0-09 selects the unique embedded profile from the wrapper, ProductCase and domain. Record-level MeasurementSpec, MeasurementResult, Claim, source-record and family mismatches are sanitized by the compiler and yield a partial run. A duplicate `(result_id, result_version)` wrapper identity fails closed.
 
 The shared envelope requires `assets=[]`, `measurement_spec_ref=null`, and `parameters={}`. `random_seed` is accepted for envelope parity but unused. Input paths, request ID, output path, and wall-clock time do not enter logical object IDs.
 
@@ -86,6 +89,8 @@ Selected catalog methods are the internal deterministic engine, bounded read-onl
 
 Executable status does not establish that a biological claim is true, that any current domain is sufficient, or that any output is scientifically releasable.
 
+Validation record: `docs/validation/p0_09_sufficiency_v2_ingestion_v0.4.md`.
+
 Detailed task card: `docs/bridge_spec_v0.1/evidence_compiler_task_card.md`.
 
 ## Field-level interface reference
@@ -96,7 +101,7 @@ Detailed task card: `docs/bridge_spec_v0.1/evidence_compiler_task_card.md`.
 |---|---|---:|---|
 | `request_id` | string | yes | Caller trace only; excluded from semantic identity |
 | `tool_id` | literal `P0-09` | yes | Must select this package |
-| `tool_version` | literal `0.3.0` or null | no | If present, must match exactly |
+| `tool_version` | literal `0.4.0` or null | no | If present, must match exactly |
 | `output_dir` | absolute path | yes | Deployment-owned destination; may not contain any structured input |
 | `assets` | array | yes | Must be empty; expression assets are outside P0-09 |
 | `measurement_spec_ref` | null | yes | MeasurementSpec belongs inside each candidate/object catalog |
@@ -117,7 +122,7 @@ Each `StructuredInputRef` requires `input_id:string`, exact `role:string`, regis
 | `comparison_ref` | `VersionedObjectRef \| null` | comparison | Exactly one for Comparison; null for Case |
 | `case_graph_refs` | `BoundCaseGraphRef[]` | comparison | 2–5 distinct source graph ID/version/manifest hash/ProductCase refs plus unique `manifest_input_id`/`record_set_input_id` bindings |
 | `external_case_evidence_refs` | `ExternalCaseEvidenceRef[]` | comparison | At least one explicit source EvidenceRecord-to-Comparison Claim mapping; exact duplicates collapse idempotently, non-identical declarations for one Evidence ref conflict |
-| `base_graph_ref` | `AppendGraphRef \| null` | case append | Prior graph ID/version/manifest checksum plus unique base manifest/record/requirement input IDs |
+| `base_graph_ref` | `AppendGraphRef \| null` | append modes | Prior graph ID/version/manifest checksum plus unique base manifest/record/requirement input IDs |
 | `object_catalog` | `CompilationObjectRef[]` | yes | Unique object ID/version, node type, Schema URI and declared content hash |
 | `candidate_records` | raw object array | case | Individually parsed `EvidenceCandidate`; siblings can fail independently |
 | `missing_observations` | raw object array | case | Individually parsed absence observations; never numeric placeholders |
@@ -126,7 +131,7 @@ Each `StructuredInputRef` requires `input_id:string`, exact `role:string`, regis
 | `created_at` | timezone-aware datetime | yes | Normalized to UTC; contributes to deterministic output time |
 | `provenance_refs` | unique string array | yes | Set semantics; path/credential strings forbidden |
 
-`VersionedObjectRef` contains `object_id` and `object_version`. `CaseGraphRef` is the pure public source identity: graph ID/version, raw manifest checksum and ProductCase ref. `BoundCaseGraphRef` adds request-local source input IDs; `AppendGraphRef` adds request-local base input IDs. Those binding IDs are never projected into a public Case/Comparison manifest. Instead, a Comparison manifest carries `external_evidence_bindings`: stable source Case graph, Evidence ref/content hash, source/comparison Claim, family, versioned sufficiency-profile ref, relation/state/tier/lifecycle/applicability and ToolRun state. It contains no caller `input_id`. A Case bundle forbids comparison fields. A Comparison bundle forbids base/owned candidate/missing/history arrays and never copies source-case scientific properties.
+`VersionedObjectRef` contains `object_id` and `object_version`. `CaseGraphRef` is the pure public source identity: graph ID/version, raw manifest checksum and ProductCase ref. `BoundCaseGraphRef` adds request-local source input IDs; `AppendGraphRef` adds request-local base input IDs. Those binding IDs are never projected into a public Case/Comparison manifest. Instead, a Comparison manifest carries `external_evidence_bindings`: stable source Case graph, Evidence ref/content hash, source/comparison Claim, family, versioned sufficiency-profile ref, relation/state/tier/lifecycle/applicability and ToolRun state. It contains no caller `input_id`. A Case bundle forbids comparison fields. A Comparison bundle forbids owned candidate/missing/history arrays, may bind only its matching prior Comparison graph in append mode, and never copies source-case scientific properties.
 
 ### EvidenceCandidate and missing observation
 
@@ -148,7 +153,7 @@ Each `StructuredInputRef` requires `input_id:string`, exact `role:string`, regis
 | `evidence_tier` | `formal \| shadow \| exploratory` | yes | Only eligible formal evidence can reconcile |
 | `applicability` | `applicable \| not_applicable \| not_assessed` | yes | Non-applicable/unassessed remains audit-only |
 | `evidence_family_ref` | versioned ref | yes | Pre-registered family and channel binding |
-| `sufficiency_profile_input_id` | string | yes | Exact request input ID of matching P0-08 profile |
+| `sufficiency_profile_input_id` | string | yes | Direct mode: exact profile input ID. Canonical-run mode: exact run-result input ID; the adapter resolves one embedded ProductCase/domain profile |
 | `tool_run_ref`, `tool_run_execution_state` | ref + enum | yes | Only succeeded/partial records compile |
 | `reference_refs`, `prior_refs`, `artifact_refs` | unique ref arrays | yes | Catalog-resolved, set semantics, content-hashed |
 | `provenance_refs` | unique string array | yes | Set semantics; no local path/token material |
@@ -170,6 +175,7 @@ Each `StructuredInputRef` requires `input_id:string`, exact `role:string`, regis
 | `ReconciliationSpecRegistry` | registry ID/version/status/time; specs | Formal evidence requires frozen registry and frozen spec |
 | `ReconciliationSpec` | ID/version/claim type, required/optional/primary/confirmation/integration roles, minimum family map, allowed states, fixed rules, review/validation/status | No weights, score thresholds, fallback method or expression language |
 | P0-08 `EvidenceSufficiencyProfile` | profile ID/version, ProductCase/MeasurementSpec/MeasurementResult bindings, retained family IDs, sufficiency state, reasons, UTC time | v0.1 matches all three object types by bare ID; v0.2 matches all three by exact ID and version. Unversioned family IDs keep formal family proof unavailable in both versions |
+| P0-08 `EvidenceSufficiencyRunResultV2` | result ID/version, source bindings, one to five v0.2 profiles, case summary and gate trace | Canonical-run modes preserve the complete wrapper as provenance and reject duplicate logical run identities; each EvidenceRecord still cites the exact resolved profile |
 
 Reason-code lists with scientific precedence preserve their declared order. Object catalogs, refs, registry entries and other explicitly set-like lists are normalized deterministically. Reordering an interpretive/temporal list changes content identity; reordering a set-like list does not.
 
@@ -234,7 +240,7 @@ Every `EvidenceGraphQueryResult` contains query name, graph ID/version, sorted n
 
 ### Stable technical and partial reason codes
 
-Top-level failures include: `tool_request_v2_required`, `tool_version_mismatch`, `p0_09_expression_assets_forbidden`, `p0_09_top_level_measurement_spec_forbidden`, `p0_09_parameters_forbidden`, exact-role/cardinality failures, `unsupported_object_input_role`, `object_input_schema_mismatch`, duplicate input/profile IDs, structured input not found/not regular/media/checksum/JSON/Schema/version failures, `unsafe_structured_input_reference`, unbound profile, `graph_scope_invalid`, `prior_history_invalid`, `output_dir_overlaps_structured_input`, `legacy_evidence_contract_rejected`, `visualization_data_invalid`, `visualization_render_failed`, input mutation, existing-bundle mismatch, graph invariant, Parquet projection and artifact/output-path checksum failure. They return failed execution, null result and no artifacts; a pre-existing output-path file is preserved.
+Top-level failures include: `tool_request_v2_required`, `tool_version_mismatch`, `p0_09_expression_assets_forbidden`, `p0_09_top_level_measurement_spec_forbidden`, `p0_09_parameters_forbidden`, exact-role/cardinality failures, `unsupported_object_input_role`, `object_input_schema_mismatch`, duplicate input/profile/run IDs, structured input not found/not regular/media/checksum/JSON/Schema/version failures, `unsafe_structured_input_reference`, unbound profile, `graph_scope_invalid`, `prior_history_invalid`, `output_dir_overlaps_structured_input`, `legacy_evidence_contract_rejected`, `visualization_data_invalid`, `visualization_render_failed`, input mutation, existing-bundle mismatch, graph invariant, Parquet projection and artifact/output-path checksum failure. They return failed execution, null result and no artifacts; a pre-existing output-path file is preserved.
 
 Record-level rejection codes are emitted in stable contract order: schema invalid, duplicate source ID, undeclared/wrong-type object, Claim not found/version/domain/relation/context mismatch, family not found/version mismatch, profile binding/case/domain/spec/MeasurementResult/family mismatch, `sufficiency_profile_version_binding_unavailable`, failed ToolRun, missing-state misuse, non-finite/invalid denominator, formal-tier gate failures, create/revision/predecessor/logical-key conflicts, duplicate logical-key conflict and invalid external mapping. Any such Schema-valid sibling rejection publishes valid facts as `partial` with `individual_records_rejected`; raw rejected content is never returned.
 
@@ -246,7 +252,7 @@ Reconciliation reasons include contract/spec not frozen or mismatched, sufficien
 {
   "request_id": "example-p0-09",
   "tool_id": "P0-09",
-  "tool_version": "0.3.0",
+  "tool_version": "0.4.0",
   "output_dir": "/absolute/output",
   "assets": [],
   "measurement_spec_ref": null,
@@ -254,7 +260,7 @@ Reconciliation reasons include contract/spec not frozen or mismatched, sufficien
   "random_seed": 0,
   "object_inputs": [
     {"input_id":"bundle","role":"compilation_bundle","schema_ref":"bridge://schemas/evidence-compilation-bundle/v0.1","object_version":"0.1.0","path":"/absolute/bundle.json","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","media_type":"application/json"},
-    {"input_id":"profile","role":"evidence_sufficiency_profile","schema_ref":"bridge://schemas/evidence-sufficiency-profile/v0.1","object_version":"0.1.0","path":"/absolute/profile.json","sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","media_type":"application/json"},
+    {"input_id":"sufficiency-run","role":"evidence_sufficiency_run_result","schema_ref":"bridge://schemas/evidence-sufficiency-run-result/v0.2","object_version":"0.2.0","path":"/absolute/evidence_sufficiency_run_result.json","sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","media_type":"application/json"},
     {"input_id":"families","role":"evidence_family_registry","schema_ref":"bridge://schemas/evidence-family-registry/v0.1","object_version":"0.1.0","path":"/absolute/families.json","sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","media_type":"application/json"},
     {"input_id":"claims","role":"claim_registry","schema_ref":"bridge://schemas/claim-registry/v0.1","object_version":"0.1.0","path":"/absolute/claims.json","sha256":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","media_type":"application/json"},
     {"input_id":"rules","role":"reconciliation_spec_registry","schema_ref":"bridge://schemas/reconciliation-spec-registry/v0.1","object_version":"0.1.0","path":"/absolute/rules.json","sha256":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","media_type":"application/json"}

--- a/src/bridge/tool_packages/p0_09_evidence_compiler/README.md
+++ b/src/bridge/tool_packages/p0_09_evidence_compiler/README.md
@@ -5,8 +5,14 @@ package.
 
 ## Interface at a glance
 
-- **Input:** compilation bundle, P0-08 profiles, EvidenceFamily, Claim and
-  Reconciliation registries, plus explicitly bound prior or comparison graphs.
+- **Input:** compilation bundle; either legacy P0-08 profiles or canonical P0-08
+  `EvidenceSufficiencyRunResultV2` objects; EvidenceFamily, Claim and
+  Reconciliation registries; plus explicitly bound prior or comparison graphs.
+  Canonical-run ingestion exposes distinct case/comparison initial/append modes:
+  case modes bind exactly one run and comparison modes bind two to five. Legacy
+  and canonical-run roles cannot be mixed. Each embedded v0.2 profile is routed
+  by the run wrapper, ProductCase and domain; MeasurementSpec, MeasurementResult,
+  Claim, source-record and family drift remains a record-level compiler check.
 - **Output:** evidence, requirement and reconciliation sets; JSON/Parquet graph
   facts; rebuild manifests; three typed explanatory figures with complete tables;
   and seven bounded read-only queries.
@@ -19,6 +25,7 @@ package.
 - [Tool Card — authoritative runtime contract](../cards/P0-09.md)
 - [Scientific task card](../../../../docs/bridge_spec_v0.1/evidence_compiler_task_card.md)
 - [Request example](../../../../examples/requests/p0_09_evidence_compiler.json)
+- [Validation record](../../../../docs/validation/p0_09_sufficiency_v2_ingestion_v0.4.md)
 
 Use `bridge-tool describe P0-09` for the installed version, schemas, environment
 and registered method IDs.

--- a/src/bridge/tool_packages/p0_09_evidence_compiler/adapter.py
+++ b/src/bridge/tool_packages/p0_09_evidence_compiler/adapter.py
@@ -24,6 +24,7 @@ from bridge.tool_packages._structured_runtime import (
 from bridge.tool_packages.p0_08_evidence_sufficiency.models import (
     EvidenceSufficiencyProfile,
     EvidenceSufficiencyProfileV2,
+    EvidenceSufficiencyRunResultV2,
 )
 from bridge.tool_packages.p0_09_evidence_compiler.compiler import (
     CompilationInvariantError,
@@ -60,6 +61,7 @@ from bridge.tool_packages.p0_09_evidence_compiler.models import (
     GraphKind,
     GraphNodeType,
     GraphRecordMode,
+    MissingEvidenceObservation,
     ReconciliationSpecRegistry,
     VersionedObjectRef,
     contains_unsafe_reference,
@@ -93,6 +95,9 @@ ROLE_SCHEMAS = {
         "bridge://schemas/evidence-sufficiency-profile/v0.1",
         "bridge://schemas/evidence-sufficiency-profile/v0.2",
     },
+    "evidence_sufficiency_run_result": {
+        "bridge://schemas/evidence-sufficiency-run-result/v0.2"
+    },
     "evidence_family_registry": {"bridge://schemas/evidence-family-registry/v0.1"},
     "claim_registry": {"bridge://schemas/claim-registry/v0.1"},
     "reconciliation_spec_registry": {"bridge://schemas/reconciliation-spec-registry/v0.1"},
@@ -112,6 +117,7 @@ ROLE_SCHEMAS = {
 ROLE_MODELS: dict[str, type[FrozenModel]] = {
     "compilation_bundle": EvidenceCompilationBundle,
     "evidence_sufficiency_profile": EvidenceSufficiencyProfile,
+    "evidence_sufficiency_run_result": EvidenceSufficiencyRunResultV2,
     "evidence_family_registry": EvidenceFamilyRegistry,
     "claim_registry": ClaimRegistry,
     "reconciliation_spec_registry": ReconciliationSpecRegistry,
@@ -130,6 +136,13 @@ class VerifiedGraphInputs:
     source_effective_lifecycle: dict[
         str, dict[str, EvidenceLifecycleState]
     ]
+
+
+@dataclass(frozen=True)
+class ResolvedSufficiencyInputs:
+    bundle: EvidenceCompilationBundle
+    profiles_by_input_id: dict[str, EvidenceSufficiencyProfile]
+    objects_by_input_id: dict[str, FrozenModel]
 
 
 @dataclass(frozen=True)
@@ -179,18 +192,11 @@ class EvidenceCompilerAdapter:
             "reconciliation_spec_registry",
             ReconciliationSpecRegistry,
         )
-        profiles = {
-            ref.input_id: loaded.objects_by_input_id[ref.input_id]
-            for ref in request.object_inputs
-            if ref.role == "evidence_sufficiency_profile"
-        }
-        if not all(isinstance(item, EvidenceSufficiencyProfile) for item in profiles.values()):
-            return _failed_run(request, spec, ["structured_input_schema_invalid"])
-        typed_profiles: dict[str, EvidenceSufficiencyProfile] = {
-            key: value for key, value in profiles.items() if isinstance(value, EvidenceSufficiencyProfile)
-        }
         try:
             verified_graph_inputs = _verify_graph_inputs(request, loaded, bundle)
+            resolved = _resolve_sufficiency_inputs(
+                request, loaded, bundle, verified_graph_inputs
+            )
         except CompilationInvariantError as exc:
             return _failed_run(request, spec, [exc.reason_code])
         input_hash = canonical_input_hash(
@@ -203,13 +209,13 @@ class EvidenceCompilerAdapter:
             compiled = compile_evidence_graph(
                 request=request,
                 spec=spec,
-                bundle=bundle,
-                profiles_by_input_id=typed_profiles,
+                bundle=resolved.bundle,
+                profiles_by_input_id=resolved.profiles_by_input_id,
                 family_registry=family_registry,
                 claim_registry=claim_registry,
                 reconciliation_registry=reconciliation_registry,
                 verified_graph_inputs=verified_graph_inputs,
-                objects_by_input_id=loaded.objects_by_input_id,
+                objects_by_input_id=resolved.objects_by_input_id,
             )
         except CompilationInvariantError as exc:
             return _failed_run(request, spec, [exc.reason_code], input_hash=input_hash)
@@ -266,10 +272,10 @@ class EvidenceCompilerAdapter:
                 staging=staging,
                 request=request,
                 spec=spec,
-                bundle=bundle,
+                bundle=resolved.bundle,
                 compiled=compiled,
                 run_id=run_id,
-                objects_by_input_id=loaded.objects_by_input_id,
+                objects_by_input_id=resolved.objects_by_input_id,
                 prepared_visualizations=prepared_visualizations,
             )
             if not _inputs_unchanged(request.object_inputs):
@@ -360,6 +366,16 @@ class EvidenceCompilerAdapter:
             reasons.append("exactly_one_claim_registry_required")
         if roles.count("reconciliation_spec_registry") != 1:
             reasons.append("exactly_one_reconciliation_registry_required")
+        if (
+            "evidence_sufficiency_profile" in roles
+            and "evidence_sufficiency_run_result" in roles
+        ):
+            reasons.append("mixed_sufficiency_input_modes")
+        if not any(
+            role in {"evidence_sufficiency_profile", "evidence_sufficiency_run_result"}
+            for role in roles
+        ):
+            reasons.append("sufficiency_input_required")
         if any(role not in ROLE_SCHEMAS for role in roles):
             reasons.append("unsupported_object_input_role")
         for ref in request.object_inputs:
@@ -392,6 +408,8 @@ def _role_model(ref: StructuredInputRef) -> type[FrozenModel] | None:
             == "bridge://schemas/evidence-sufficiency-profile/v0.2"
             else EvidenceSufficiencyProfile
         )
+    if ref.role == "evidence_sufficiency_run_result":
+        return EvidenceSufficiencyRunResultV2
     if ref.role in {"base_graph_manifest", "source_case_graph_manifest"}:
         if ref.schema_ref == "bridge://schemas/case-evidence-graph-manifest/v0.1":
             return CaseEvidenceGraphManifest
@@ -411,7 +429,8 @@ def _validate_input_payload(ref: StructuredInputRef, payload: Any) -> None:
         else payload
     )
     if (
-        ref.role != "evidence_sufficiency_profile"
+        ref.role
+        not in {"evidence_sufficiency_profile", "evidence_sufficiency_run_result"}
         and _contains_legacy_contract(no_score_payload)
     ):
         raise StructuredInputError("legacy_evidence_contract_rejected")
@@ -433,6 +452,7 @@ def _validate_declared_version(ref: StructuredInputRef, value: FrozenModel) -> N
         "registry_version",
         "record_set_version",
         "requirement_set_version",
+        "result_version",
         "graph_version",
         "version",
     ):
@@ -470,93 +490,404 @@ def _top_level_raw_payload(role: str, value: Any) -> Any:
 
 def _binding_reasons(request: ToolRequestV2, loaded: LoadedInputs) -> list[str]:
     reasons: list[str] = []
-    bundles = _objects_for_role(request, loaded, "compilation_bundle", EvidenceCompilationBundle)
+    bundles = _objects_for_role(
+        request, loaded, "compilation_bundle", EvidenceCompilationBundle
+    )
     if len(bundles) != 1:
         return ["exactly_one_compilation_bundle_required"]
     bundle = bundles[0]
-    profiles = {
-        ref.input_id: loaded.objects_by_input_id[ref.input_id]
-        for ref in request.object_inputs
-        if ref.role == "evidence_sufficiency_profile"
-    }
-    profile_count = len(profiles)
-    if bundle.graph_kind is GraphKind.CASE:
-        if not 1 <= profile_count <= 5:
-            reasons.append("sufficiency_profile_cardinality_invalid")
-        bound_ids = {
-            item.get("sufficiency_profile_input_id")
-            for item in bundle.candidate_records
-            if isinstance(item, dict)
-            and isinstance(item.get("sufficiency_profile_input_id"), str)
-        }
-        profile_input_by_ref = {
-            f"{profile.profile_id}@{profile.profile_version}": input_id
-            for input_id, profile in profiles.items()
-            if isinstance(profile, EvidenceSufficiencyProfile)
-        }
-        bound_ids.update(
-            profile_input_by_ref[record.sufficiency_profile_ref.ref]
-            for record in bundle.prior_evidence_records
-            if record.sufficiency_profile_ref.ref in profile_input_by_ref
-        )
-    else:
-        if not 2 <= profile_count <= 25:
-            reasons.append("sufficiency_profile_cardinality_invalid")
-        bound_ids = {
-            value
-            for item in bundle.external_case_evidence_refs
-            if isinstance(value := _external_profile_input_id(item), str)
-        }
-    if set(profiles) != bound_ids:
-        reasons.append("unbound_sufficiency_profile")
-    profile_ids = [
-        item.profile_id
-        for item in profiles.values()
-        if isinstance(item, EvidenceSufficiencyProfile)
-    ]
-    if len(profile_ids) != len(set(profile_ids)):
-        reasons.append("duplicate_sufficiency_profile_id")
+    verified_graph_inputs: VerifiedGraphInputs | None = None
     try:
-        claims = _objects_for_role(request, loaded, "claim_registry", ClaimRegistry)
-        family_registries = _objects_for_role(
-            request, loaded, "evidence_family_registry", EvidenceFamilyRegistry
-        )
-        validate_prior_history(
-            bundle,
-            profiles_by_input_id={
-                key: value
-                for key, value in profiles.items()
-                if isinstance(value, EvidenceSufficiencyProfile)
-            },
-            claims=(
-                {
-                    (item.claim_id, item.version): item
-                    for item in claims[0].claims
-                }
-                if len(claims) == 1
-                else None
-            ),
-            families=(
-                {
-                    (item.evidence_family_id, item.version): item
-                    for item in family_registries[0].families
-                }
-                if len(family_registries) == 1
-                else None
-            ),
-        )
+        verified_graph_inputs = _verify_graph_inputs(request, loaded, bundle)
     except CompilationInvariantError as exc:
         reasons.append(exc.reason_code)
-    try:
-        _verify_graph_inputs(request, loaded, bundle)
-    except CompilationInvariantError as exc:
-        reasons.append(exc.reason_code)
+    if verified_graph_inputs is not None:
+        try:
+            resolved = _resolve_sufficiency_inputs(
+                request, loaded, bundle, verified_graph_inputs
+            )
+            claims = _objects_for_role(request, loaded, "claim_registry", ClaimRegistry)
+            family_registries = _objects_for_role(
+                request, loaded, "evidence_family_registry", EvidenceFamilyRegistry
+            )
+            validate_prior_history(
+                resolved.bundle,
+                profiles_by_input_id=resolved.profiles_by_input_id,
+                claims=(
+                    {
+                        (item.claim_id, item.version): item
+                        for item in claims[0].claims
+                    }
+                    if len(claims) == 1
+                    else None
+                ),
+                families=(
+                    {
+                        (item.evidence_family_id, item.version): item
+                        for item in family_registries[0].families
+                    }
+                    if len(family_registries) == 1
+                    else None
+                ),
+            )
+        except CompilationInvariantError as exc:
+            reasons.append(exc.reason_code)
     resolved_output = request.output_dir.resolve()
     for ref in request.object_inputs:
         resolved_input = ref.path.resolve()
-        if resolved_input == resolved_output or resolved_input.is_relative_to(resolved_output):
+        if resolved_input == resolved_output or resolved_input.is_relative_to(
+            resolved_output
+        ):
             reasons.append("output_dir_overlaps_structured_input")
     return sorted(set(reasons))
+
+
+def _resolve_sufficiency_inputs(
+    request: ToolRequestV2,
+    loaded: LoadedInputs,
+    bundle: EvidenceCompilationBundle,
+    verified_graph_inputs: VerifiedGraphInputs,
+) -> ResolvedSufficiencyInputs:
+    profile_refs = [
+        ref
+        for ref in request.object_inputs
+        if ref.role == "evidence_sufficiency_profile"
+    ]
+    run_refs = [
+        ref
+        for ref in request.object_inputs
+        if ref.role == "evidence_sufficiency_run_result"
+    ]
+    if profile_refs and run_refs:
+        raise CompilationInvariantError("mixed_sufficiency_input_modes")
+    if profile_refs:
+        profiles = {
+            ref.input_id: loaded.objects_by_input_id[ref.input_id]
+            for ref in profile_refs
+        }
+        if not all(
+            isinstance(item, EvidenceSufficiencyProfile)
+            for item in profiles.values()
+        ):
+            raise CompilationInvariantError("structured_input_schema_invalid")
+        typed_profiles = {
+            key: value
+            for key, value in profiles.items()
+            if isinstance(value, EvidenceSufficiencyProfile)
+        }
+        expected = (1, 5) if bundle.graph_kind is GraphKind.CASE else (2, 25)
+        if not expected[0] <= len(typed_profiles) <= expected[1]:
+            raise CompilationInvariantError("sufficiency_profile_cardinality_invalid")
+        if bundle.graph_kind is GraphKind.CASE:
+            bound_ids = {
+                item.get("sufficiency_profile_input_id")
+                for item in bundle.candidate_records
+                if isinstance(item, dict)
+                and isinstance(item.get("sufficiency_profile_input_id"), str)
+            }
+            profile_input_by_ref = {
+                f"{profile.profile_id}@{profile.profile_version}": input_id
+                for input_id, profile in typed_profiles.items()
+            }
+            bound_ids.update(
+                profile_input_by_ref[record.sufficiency_profile_ref.ref]
+                for record in bundle.prior_evidence_records
+                if record.sufficiency_profile_ref.ref in profile_input_by_ref
+            )
+        else:
+            bound_ids = {
+                value
+                for item in bundle.external_case_evidence_refs
+                if isinstance(value := _external_profile_input_id(item), str)
+            }
+        if set(typed_profiles) != bound_ids:
+            raise CompilationInvariantError("unbound_sufficiency_profile")
+        if len({item.profile_id for item in typed_profiles.values()}) != len(
+            typed_profiles
+        ):
+            raise CompilationInvariantError("duplicate_sufficiency_profile_id")
+        return ResolvedSufficiencyInputs(
+            bundle=bundle,
+            profiles_by_input_id=typed_profiles,
+            objects_by_input_id=dict(loaded.objects_by_input_id),
+        )
+    if not run_refs:
+        raise CompilationInvariantError("sufficiency_input_required")
+    runs = {
+        ref.input_id: loaded.objects_by_input_id[ref.input_id]
+        for ref in run_refs
+    }
+    if not all(
+        isinstance(item, EvidenceSufficiencyRunResultV2)
+        for item in runs.values()
+    ):
+        raise CompilationInvariantError("structured_input_schema_invalid")
+    typed_runs = {
+        key: value
+        for key, value in runs.items()
+        if isinstance(value, EvidenceSufficiencyRunResultV2)
+    }
+    if (
+        bundle.graph_kind is GraphKind.CASE
+        and len(typed_runs) != 1
+    ) or (
+        bundle.graph_kind is GraphKind.COMPARISON
+        and not 2 <= len(typed_runs) <= 5
+    ):
+        raise CompilationInvariantError("sufficiency_run_cardinality_invalid")
+    run_identities = [
+        (result.result_id, result.result_version)
+        for result in typed_runs.values()
+    ]
+    if len(run_identities) != len(set(run_identities)):
+        raise CompilationInvariantError("duplicate_sufficiency_run_id")
+
+    run_case_refs = {
+        input_id: _object_ref_key(result.case_summary.product_case_ref)
+        for input_id, result in typed_runs.items()
+    }
+    if any(ref is None for ref in run_case_refs.values()):
+        raise CompilationInvariantError("sufficiency_run_case_binding_invalid")
+    if bundle.graph_kind is GraphKind.CASE:
+        if set(run_case_refs.values()) != {_object_ref_key(bundle.product_case_ref)}:
+            raise CompilationInvariantError("sufficiency_run_case_binding_invalid")
+    else:
+        expected_cases = {
+            _object_ref_key(item.product_case_ref) for item in bundle.case_graph_refs
+        }
+        if (
+            len(run_case_refs.values()) != len(set(run_case_refs.values()))
+            or set(run_case_refs.values()) != expected_cases
+        ):
+            raise CompilationInvariantError("sufficiency_run_case_binding_invalid")
+
+    profiles_by_key: dict[str, EvidenceSufficiencyProfileV2] = {}
+    profiles_by_run: dict[str, list[tuple[str, EvidenceSufficiencyProfileV2]]] = {}
+    profile_refs_seen: set[str] = set()
+    for run_input_id, result in typed_runs.items():
+        for profile in result.profiles:
+            profile_ref = f"{profile.profile_id}@{profile.profile_version}"
+            if profile_ref in profile_refs_seen:
+                raise CompilationInvariantError("duplicate_sufficiency_profile_id")
+            profile_refs_seen.add(profile_ref)
+            key_digest = hashlib.sha256(
+                (
+                    f"{result.result_id}@{result.result_version}|"
+                    f"{profile_ref}"
+                ).encode("utf-8")
+            ).hexdigest()[:24]
+            key = f"sufficiency-profile-binding:{key_digest}"
+            if key in profiles_by_key:
+                raise CompilationInvariantError("duplicate_sufficiency_profile_id")
+            profiles_by_key[key] = profile
+            profiles_by_run.setdefault(run_input_id, []).append((key, profile))
+
+    if set(profiles_by_key) & set(loaded.objects_by_input_id):
+        raise CompilationInvariantError(
+            "sufficiency_profile_binding_id_collision"
+        )
+
+    claims = _objects_for_role(request, loaded, "claim_registry", ClaimRegistry)
+    claim_by_ref = (
+        {
+            (item.claim_id, item.version): item
+            for item in claims[0].claims
+        }
+        if len(claims) == 1
+        else {}
+    )
+    bound_profile_keys: set[str] = set()
+    rewritten_candidates: list[dict[str, Any]] = []
+    for raw in bundle.candidate_records:
+        run_input_id = raw.get("sufficiency_profile_input_id")
+        if not isinstance(run_input_id, str):
+            rewritten_candidates.append(raw)
+            continue
+        choices = profiles_by_run.get(run_input_id)
+        if choices is None:
+            raise CompilationInvariantError("sufficiency_run_profile_binding_invalid")
+        claim = claim_by_ref.get(_object_ref_key(raw.get("claim_ref")))
+        domain_id = (
+            claim.domain_id
+            if claim is not None
+            else raw.get("domain_id")
+            if isinstance(raw.get("domain_id"), str)
+            else None
+        )
+        profile_key, _ = _select_embedded_profile(
+            choices,
+            product_case_ref=bundle.product_case_ref,
+            domain_id=domain_id,
+            allow_single_profile_fallback=True,
+        )
+        bound_profile_keys.add(profile_key)
+        rewritten_candidates.append(
+            {**raw, "sufficiency_profile_input_id": profile_key}
+        )
+
+    for record in bundle.prior_evidence_records:
+        profile_key, _ = _select_embedded_profile(
+            list(profiles_by_key.items()),
+            product_case_ref=bundle.product_case_ref,
+            profile_ref=_object_ref_key(record.sufficiency_profile_ref),
+        )
+        bound_profile_keys.add(profile_key)
+
+    case_choices = next(iter(profiles_by_run.values()), [])
+    for raw in bundle.missing_observations:
+        try:
+            observation = MissingEvidenceObservation.model_validate(raw)
+        except ValueError:
+            continue
+        claim = claim_by_ref.get(_object_ref_key(observation.claim_ref))
+        if claim is None:
+            continue
+        profile_key, _ = _select_embedded_profile(
+            case_choices,
+            product_case_ref=bundle.product_case_ref,
+            domain_id=claim.domain_id,
+            measurement_spec_ref=_object_ref_key(
+                observation.source_contract_ref
+            ),
+        )
+        bound_profile_keys.add(profile_key)
+
+    rewritten_externals: list[ExternalCaseEvidenceRef | dict[str, Any]] = []
+    for raw_item in bundle.external_case_evidence_refs:
+        raw = (
+            raw_item.model_dump(mode="json")
+            if isinstance(raw_item, ExternalCaseEvidenceRef)
+            else raw_item
+        )
+        run_input_id = raw.get("sufficiency_profile_input_id")
+        if not isinstance(run_input_id, str):
+            rewritten_externals.append(raw)
+            continue
+        choices = profiles_by_run.get(run_input_id)
+        if choices is None:
+            raise CompilationInvariantError("sufficiency_run_profile_binding_invalid")
+        try:
+            external = ExternalCaseEvidenceRef.model_validate(raw)
+        except ValueError:
+            external = None
+        source_set = (
+            verified_graph_inputs.source_record_sets.get(
+                external.source_case_graph_ref.graph_id
+            )
+            if external is not None
+            else None
+        )
+        source_record = next(
+            (
+                item
+                for item in (source_set.records if source_set is not None else [])
+                if external is not None and item.ref == external.evidence_ref
+            ),
+            None,
+        )
+        comparison_claim = claim_by_ref.get(
+            _object_ref_key(
+                external.comparison_claim_ref
+                if external is not None
+                else raw.get("comparison_claim_ref")
+            )
+        )
+        domain_id = (
+            comparison_claim.domain_id
+            if comparison_claim is not None
+            else source_record.domain_id
+            if source_record is not None
+            else None
+        )
+        profile_key, _ = _select_embedded_profile(
+            choices,
+            product_case_ref=typed_runs[run_input_id].case_summary.product_case_ref,
+            domain_id=domain_id,
+            allow_single_profile_fallback=True,
+        )
+        bound_profile_keys.add(profile_key)
+        rewritten_externals.append(
+            external.model_copy(update={"sufficiency_profile_input_id": profile_key})
+            if external is not None
+            else {**raw, "sufficiency_profile_input_id": profile_key}
+        )
+
+    if set(profiles_by_key) != bound_profile_keys:
+        raise CompilationInvariantError("unbound_sufficiency_profile")
+    resolved_bundle = bundle.model_copy(
+        update={
+            "candidate_records": rewritten_candidates,
+            "external_case_evidence_refs": rewritten_externals,
+        }
+    )
+    resolved_objects = dict(loaded.objects_by_input_id)
+    resolved_objects.update(profiles_by_key)
+    return ResolvedSufficiencyInputs(
+        bundle=resolved_bundle,
+        profiles_by_input_id=dict(profiles_by_key),
+        objects_by_input_id=resolved_objects,
+    )
+
+
+def _object_ref_key(value: Any) -> tuple[str, str] | None:
+    if isinstance(value, Mapping):
+        object_id = value.get("object_id")
+        object_version = value.get("object_version")
+    else:
+        object_id = getattr(value, "object_id", None)
+        object_version = getattr(value, "object_version", None)
+    if not isinstance(object_id, str) or not isinstance(object_version, str):
+        return None
+    return object_id, object_version
+
+
+def _select_embedded_profile(
+    choices: list[tuple[str, EvidenceSufficiencyProfileV2]],
+    *,
+    product_case_ref: Any,
+    domain_id: Any = None,
+    measurement_spec_ref: tuple[str, str] | None = None,
+    profile_ref: tuple[str, str] | None = None,
+    allow_single_profile_fallback: bool = False,
+) -> tuple[str, EvidenceSufficiencyProfileV2]:
+    case_ref = _object_ref_key(product_case_ref)
+    case_choices = [
+        item
+        for item in choices
+        if _object_ref_key(item[1].product_case_ref) == case_ref
+    ]
+    matches = case_choices
+    if profile_ref is not None:
+        matches = [
+            item
+            for item in matches
+            if (item[1].profile_id, item[1].profile_version) == profile_ref
+        ]
+    if measurement_spec_ref is not None:
+        matches = [
+            item
+            for item in matches
+            if _object_ref_key(item[1].measurement_spec_ref)
+            == measurement_spec_ref
+        ]
+    if domain_id is not None:
+        domain_value = getattr(domain_id, "value", domain_id)
+        matches = [
+            item
+            for item in matches
+            if item[1].domain_id is not None
+            and item[1].domain_id.value == domain_value
+        ]
+    if len(matches) == 1:
+        return matches[0]
+    if (
+        allow_single_profile_fallback
+        and profile_ref is None
+        and measurement_spec_ref is None
+        and len(case_choices) == 1
+    ):
+        return case_choices[0]
+    raise CompilationInvariantError("sufficiency_run_profile_binding_invalid")
 
 
 def _verify_graph_inputs(

--- a/src/bridge/tool_packages/p0_09_evidence_compiler/adapter.py
+++ b/src/bridge/tool_packages/p0_09_evidence_compiler/adapter.py
@@ -746,9 +746,6 @@ def _resolve_sufficiency_inputs(
             case_choices,
             product_case_ref=bundle.product_case_ref,
             domain_id=claim.domain_id,
-            measurement_spec_ref=_object_ref_key(
-                observation.source_contract_ref
-            ),
         )
         bound_profile_keys.add(profile_key)
 
@@ -846,7 +843,6 @@ def _select_embedded_profile(
     *,
     product_case_ref: Any,
     domain_id: Any = None,
-    measurement_spec_ref: tuple[str, str] | None = None,
     profile_ref: tuple[str, str] | None = None,
     allow_single_profile_fallback: bool = False,
 ) -> tuple[str, EvidenceSufficiencyProfileV2]:
@@ -863,13 +859,6 @@ def _select_embedded_profile(
             for item in matches
             if (item[1].profile_id, item[1].profile_version) == profile_ref
         ]
-    if measurement_spec_ref is not None:
-        matches = [
-            item
-            for item in matches
-            if _object_ref_key(item[1].measurement_spec_ref)
-            == measurement_spec_ref
-        ]
     if domain_id is not None:
         domain_value = getattr(domain_id, "value", domain_id)
         matches = [
@@ -883,7 +872,6 @@ def _select_embedded_profile(
     if (
         allow_single_profile_fallback
         and profile_ref is None
-        and measurement_spec_ref is None
         and len(case_choices) == 1
     ):
         return case_choices[0]

--- a/src/bridge/tool_packages/p0_09_evidence_compiler/models.py
+++ b/src/bridge/tool_packages/p0_09_evidence_compiler/models.py
@@ -951,14 +951,9 @@ class EvidenceCompilationBundle(FrozenModel):
             )
             if not self.external_case_evidence_refs:
                 raise ValueError("comparison bundle requires external case evidence")
-            if (
-                self.base_graph_ref is not None
-                or
-                self.candidate_records
-                or self.missing_observations
-                or self.prior_evidence_records
-                or self.prior_requirements
-            ):
+            if self.candidate_records or self.missing_observations:
+                raise ValueError("comparison bundle cannot own case evidence candidates")
+            if self.prior_evidence_records or self.prior_requirements:
                 raise ValueError("comparison bundle cannot own case evidence history")
         return self
 

--- a/src/bridge/tool_packages/specs/p0_09.yaml
+++ b/src/bridge/tool_packages/specs/p0_09.yaml
@@ -1,6 +1,6 @@
 tool_id: P0-09
 name: Evidence Compiler & Reconciler
-version: 0.3.0
+version: 0.4.0
 summary: Compile atomic evidence and reconcile conflicts by versioned rules.
 implementation_state: implemented
 scientific_status: candidate

--- a/tests/test_p0_09_evidence_compiler.py
+++ b/tests/test_p0_09_evidence_compiler.py
@@ -4233,6 +4233,85 @@ def test_case_initial_v2_missing_only_creates_requirement_without_zero_record(
     assert all("value" not in item for item in requirements)
 
 
+def test_case_initial_v2_accepts_claim_contract_missing_observation(
+    tmp_path: Path,
+) -> None:
+    missing = _missing_observation()
+    bundle = _bundle(candidates=[], missing=[missing])
+    request = _request(
+        tmp_path,
+        bundle=bundle,
+        request_id="case-v2-claim-contract-missing",
+        output_name="case-v2-claim-contract-missing-output",
+        family_registry=_family_registry(second_family=True),
+        claim_registry=_claim_registry(orthogonal_required=True),
+        reconciliation_registry=_reconciliation_registry(
+            orthogonal_required=True
+        ),
+        sufficiency_runs=[("sufficiency-run", _v2_run(_profile()))],
+    )
+
+    run = _run_request(request)
+
+    assert run.execution_state is ExecutionState.SUCCEEDED
+    final = run.request.output_dir / run.run_id
+    requirements = json.loads(
+        (final / "evidence_requirements.json").read_text()
+    )["requirements"]
+    orthogonal = next(
+        item
+        for item in requirements
+        if item["requirement_key"] == "orthogonal_channel"
+    )
+    assert orthogonal["source_contract_ref"] == missing["source_contract_ref"]
+    assert json.loads((final / "evidence_records.json").read_text())["records"] == []
+
+
+def test_case_initial_v2_invalid_missing_contract_is_partial_and_keeps_candidate(
+    tmp_path: Path,
+) -> None:
+    missing = _missing_observation()
+    missing["source_contract_ref"] = {
+        "object_id": "measurement-spec:not-registered",
+        "object_version": "1.0.0",
+    }
+    bundle = _bundle(missing=[missing])
+    bundle["candidate_records"][0]["sufficiency_profile_input_id"] = (
+        "sufficiency-run"
+    )
+    request = _request(
+        tmp_path,
+        bundle=bundle,
+        request_id="case-v2-invalid-missing-contract",
+        output_name="case-v2-invalid-missing-contract-output",
+        family_registry=_family_registry(second_family=True),
+        claim_registry=_claim_registry(orthogonal_required=True),
+        reconciliation_registry=_reconciliation_registry(
+            orthogonal_required=True
+        ),
+        sufficiency_runs=[("sufficiency-run", _v2_run(_profile()))],
+    )
+
+    run = _run_request(request)
+
+    assert run.execution_state is ExecutionState.PARTIAL
+    assert run.reason_codes == ["individual_records_rejected"]
+    final = run.request.output_dir / run.run_id
+    records = json.loads((final / "evidence_records.json").read_text())["records"]
+    rejected = json.loads((final / "rejected_records.json").read_text())["records"]
+    assert len(records) == 1
+    assert rejected == [
+        {
+            "source_kind": "missing_observation",
+            "source_id": missing["observation_id"],
+            "source_index": 0,
+            "reason_codes": ["declared_object_ref_not_found"],
+            "claim_ref": "claim:target-identity@1.0.0",
+            "logical_key_digest": None,
+        }
+    ]
+
+
 def test_comparison_v2_duplicate_run_identity_fails_closed(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_p0_09_evidence_compiler.py
+++ b/tests/test_p0_09_evidence_compiler.py
@@ -21,6 +21,7 @@ from bridge.tool_packages.p0_08_evidence_sufficiency.models import (
     EvidenceSufficiencyProfile,
     P0DomainId,
     EvidenceSufficiencyProfileV2,
+    EvidenceSufficiencyRunResultV2,
 )
 from bridge.tool_packages.p0_09_evidence_compiler.models import (
     PUBLIC_SCHEMA_MODELS,
@@ -36,6 +37,7 @@ from bridge.tool_packages.p0_09_evidence_compiler.models import (
     EvidenceRecord,
     EvidenceRequirement,
     CaseEvidenceGraphManifest,
+    ComparisonEvidenceGraphManifest,
     MissingEvidenceObservation,
     EvidenceFamilyRegistry,
     GraphArtifactRef,
@@ -121,7 +123,7 @@ def _spec() -> ToolPackageSpecV2:
     return ToolPackageSpecV2(
         tool_id="P0-09",
         name="Evidence Compiler & Reconciler",
-        version="0.3.0",
+        version="0.4.0",
         summary="Compile atomic evidence and reconcile conflicts by versioned rules.",
         implementation_state=ImplementationState.IMPLEMENTED,
         scientific_status="candidate",
@@ -855,10 +857,15 @@ def _request(
     output_name: str = "output",
     base_manifest_path: Path | None = None,
     source_case_manifest_paths: list[Path] | None = None,
+    sufficiency_runs: list[tuple[str, dict[str, Any]]] | None = None,
 ) -> ToolRequestV2:
     inputs = tmp_path / f"inputs-{request_id}"
     manifest_paths_by_input_id: dict[str, Path] = {}
-    profile_objects = profiles or [("profile-target", profile or _profile())]
+    profile_objects = (
+        [(input_id, payload["profiles"][0]) for input_id, payload in sufficiency_runs]
+        if sufficiency_runs is not None
+        else profiles or [("profile-target", profile or _profile())]
+    )
     effective_bundle = json.loads(json.dumps(bundle or _bundle()))
     if (
         effective_bundle["graph_kind"] == "comparison"
@@ -897,20 +904,33 @@ def _request(
             "0.1.0",
         ),
     ]
-    objects[1:1] = [
-        (
-            input_id,
-            "evidence_sufficiency_profile",
+    objects[1:1] = (
+        [
             (
-                "bridge://schemas/evidence-sufficiency-profile/v0.2"
-                if payload["profile_version"] == "0.2.0"
-                else "bridge://schemas/evidence-sufficiency-profile/v0.1"
-            ),
-            payload,
-            payload["profile_version"],
-        )
-        for input_id, payload in profile_objects
-    ]
+                input_id,
+                "evidence_sufficiency_run_result",
+                "bridge://schemas/evidence-sufficiency-run-result/v0.2",
+                payload,
+                "0.2.0",
+            )
+            for input_id, payload in sufficiency_runs
+        ]
+        if sufficiency_runs is not None
+        else [
+            (
+                input_id,
+                "evidence_sufficiency_profile",
+                (
+                    "bridge://schemas/evidence-sufficiency-profile/v0.2"
+                    if payload["profile_version"] == "0.2.0"
+                    else "bridge://schemas/evidence-sufficiency-profile/v0.1"
+                ),
+                payload,
+                payload["profile_version"],
+            )
+            for input_id, payload in profile_objects
+        ]
+    )
     if base_manifest_path is not None:
         manifest_paths_by_input_id["base-manifest"] = base_manifest_path
         base_manifest = json.loads(base_manifest_path.read_text())
@@ -992,7 +1012,7 @@ def _request(
     return ToolRequestV2(
         request_id=request_id,
         tool_id="P0-09",
-        tool_version="0.3.0",
+        tool_version="0.4.0",
         output_dir=(tmp_path / output_name).resolve(),
         assets=[],
         measurement_spec_ref=None,
@@ -1774,7 +1794,7 @@ def test_v1_adapter_invocation_has_one_stable_v2_reason(tmp_path: Path) -> None:
     request = ToolRequest(
         request_id="p0-09-v1",
         tool_id="P0-09",
-        tool_version="0.3.0",
+        tool_version="0.4.0",
         output_dir=(tmp_path / "output").resolve(),
     )
     eligibility = adapter.check_eligibility(request, _spec())  # type: ignore[arg-type]
@@ -3715,6 +3735,122 @@ def _v2_profile(
     return payload
 
 
+def _v2_run(profile_payload: dict[str, Any]) -> dict[str, Any]:
+    profile = EvidenceSufficiencyProfileV2.model_validate(
+        _v2_profile(profile_payload)
+        if profile_payload["profile_version"] == "0.1.0"
+        else profile_payload
+    )
+    digest = profile.profile_id.split(":", 2)[1]
+    assert profile.domain_id is not None
+    assert profile.product_case_ref is not None
+    assert profile.measurement_spec_ref is not None
+    assert profile.qc_profile_ref is not None
+    bindings = [
+        {
+            "input_id": f"domain-{profile.domain_id.value}",
+            "role": "domain_gate_input",
+            "logical_object_id": (
+                f"domain-gate-input:{digest}:{profile.domain_id.value}"
+            ),
+            "object_version": "0.1.0",
+            "schema_ref": "bridge://schemas/domain-gate-input/v0.1",
+            "source_sha256": "1" * 64,
+        },
+        {
+            "input_id": "product-case",
+            "role": "product_case",
+            "logical_object_id": profile.product_case_ref.object_id,
+            "object_version": profile.product_case_ref.object_version,
+            "schema_ref": "bridge://schemas/product-case/v0.1",
+            "source_sha256": "f" * 64,
+        },
+        {
+            "input_id": "gate-rules",
+            "role": "gate_rule_spec",
+            "logical_object_id": "GATE-EVIDENCE-SUFFICIENCY-v0.2",
+            "object_version": "0.2.0",
+            "schema_ref": (
+                "bridge://schemas/evidence-sufficiency-gate-rule-spec/v0.2"
+            ),
+            "source_sha256": "2" * 64,
+        },
+        *[
+            {
+                "input_id": f"measurement-{index}",
+                "role": "measurement_result",
+                "logical_object_id": item.object_id,
+                "object_version": item.object_version,
+                "schema_ref": "bridge://schemas/measurement-result/v0.2",
+                "source_sha256": f"{index + 3:x}" * 64,
+            }
+            for index, item in enumerate(profile.measurement_result_refs)
+        ],
+        {
+            "input_id": "measurement-spec",
+            "role": "measurement_spec",
+            "logical_object_id": profile.measurement_spec_ref.object_id,
+            "object_version": profile.measurement_spec_ref.object_version,
+            "schema_ref": "bridge://schemas/measurement-spec/v0.2",
+            "source_sha256": "d" * 64,
+        },
+        {
+            "input_id": "qc-profile",
+            "role": "qc_readiness_profile",
+            "logical_object_id": profile.qc_profile_ref.object_id,
+            "object_version": profile.qc_profile_ref.object_version,
+            "schema_ref": "bridge://schemas/qc-readiness-profile/v0.2",
+            "source_sha256": "e" * 64,
+        },
+    ]
+    bindings.sort(key=lambda item: (item["role"], item["input_id"]))
+    state_counts = {
+        state: int(profile.evidence_sufficiency_state.value == state)
+        for state in ("sufficient", "limited", "insufficient", "not_assessed")
+    }
+    payload = {
+        "result_id": f"evidence-sufficiency-result:{digest}",
+        "result_version": "0.2.0",
+        "gate_rule_spec_ref": "GATE-EVIDENCE-SUFFICIENCY-v0.2",
+        "source_object_bindings": bindings,
+        "profiles": [profile.model_dump(mode="json")],
+        "case_summary": {
+            "summary_id": f"case-evidence-readiness-summary:{digest}",
+            "summary_version": "0.2.0",
+            "product_case_ref": profile.product_case_ref.model_dump(mode="json"),
+            "profile_count": 1,
+            "evidence_sufficiency_counts": state_counts,
+            "score_state_counts": {"unavailable": 1},
+            "blocking_reasons": profile.blocking_reasons,
+            "measurement_evidence_state_counts": (
+                profile.measurement_evidence_state_counts.model_dump(mode="json")
+            ),
+        },
+        "gate_trace": [
+            {
+                "profile_ref": profile.profile_id,
+                "domain_gate_input_ref": (
+                    f"domain-gate-input:{digest}:{profile.domain_id.value}"
+                ),
+                "evaluated_precedence": (
+                    "not_assessed",
+                    "insufficient",
+                    "limited",
+                    "sufficient",
+                ),
+                "selected_state": profile.evidence_sufficiency_state.value,
+                "selected_reason_codes": (
+                    profile.blocking_reasons or ["raw_evidence_gate_sufficient"]
+                ),
+                "ignored_duplicate_input_refs": [],
+            }
+        ],
+    }
+    return EvidenceSufficiencyRunResultV2.model_validate(payload).model_dump(
+        mode="json"
+    )
+
+
 def _request_with_v2_profile(
     tmp_path: Path,
     *,
@@ -3744,6 +3880,546 @@ def _request_with_v2_profile(
                 for item in request.object_inputs
             ]
         }
+    )
+
+
+def _run_request(request: ToolRequestV2):
+    return adapter.run(request, _spec())
+
+
+def _case_v2_request(
+    tmp_path: Path,
+    *,
+    bundle: dict[str, Any] | None = None,
+    request_id: str = "case-v2",
+    output_name: str = "case-v2-output",
+    base_manifest_path: Path | None = None,
+) -> ToolRequestV2:
+    effective_bundle = json.loads(json.dumps(bundle or _bundle()))
+    for candidate in effective_bundle["candidate_records"]:
+        candidate["sufficiency_profile_input_id"] = "sufficiency-run"
+    return _request(
+        tmp_path,
+        bundle=effective_bundle,
+        request_id=request_id,
+        output_name=output_name,
+        base_manifest_path=base_manifest_path,
+        sufficiency_runs=[("sufficiency-run", _v2_run(_profile()))],
+    )
+
+
+def _comparison_v2_inputs(
+    bundle: dict[str, Any],
+) -> tuple[dict[str, Any], list[tuple[str, dict[str, Any]]]]:
+    bundle = json.loads(json.dumps(bundle))
+    direct_profiles = _comparison_profiles()
+    runs = []
+    for index, (_profile_input_id, profile) in enumerate(direct_profiles):
+        run_input_id = f"sufficiency-run-{index}"
+        bundle["external_case_evidence_refs"][index][
+            "sufficiency_profile_input_id"
+        ] = run_input_id
+        runs.append((run_input_id, _v2_run(profile)))
+    return bundle, runs
+
+
+def test_case_initial_v2_consumes_canonical_run_and_preserves_exact_profile_refs(
+    tmp_path: Path,
+) -> None:
+    request = _case_v2_request(tmp_path)
+    run_input = next(
+        item
+        for item in request.object_inputs
+        if item.role == "evidence_sufficiency_run_result"
+    )
+    run_payload = json.loads(run_input.path.read_text())
+    product_bindings = [
+        item
+        for item in run_payload["source_object_bindings"]
+        if item["role"] == "product_case"
+    ]
+    assert product_bindings == [
+        {
+            "input_id": "product-case",
+            "role": "product_case",
+            "logical_object_id": "product-case:synthetic-001",
+            "object_version": "1.0.0",
+            "schema_ref": "bridge://schemas/product-case/v0.1",
+            "source_sha256": "f" * 64,
+        }
+    ]
+
+    run = _run_request(request)
+
+    assert run.execution_state is ExecutionState.SUCCEEDED
+    final = run.request.output_dir / run.run_id
+    records = EvidenceRecordSet.model_validate_json(
+        (final / "evidence_records.json").read_bytes()
+    )
+    assert records.records[0].sufficiency_profile_ref.object_version == "0.2.0"
+    assert records.records[0].measurement_result_ref.object_version == "1.0.0"
+    manifest = json.loads((final / "artifact_manifest.json").read_text())
+    graph_manifest = json.loads(
+        (final / "case_evidence_graph_manifest.json").read_text()
+    )
+    assert run.run_id == f"run-{run.input_hash[:16]}"
+    assert manifest["run_id"] == run.run_id
+    assert manifest["input_hash"] == run.input_hash
+    assert graph_manifest["source_input_hash"] == run.input_hash
+    run_inputs = [
+        item
+        for item in manifest["structured_inputs"]
+        if item["role"] == "evidence_sufficiency_run_result"
+    ]
+    assert len(run_inputs) == 1
+    assert run_inputs[0]["schema_ref"] == (
+        "bridge://schemas/evidence-sufficiency-run-result/v0.2"
+    )
+    assert run_inputs[0]["object_version"] == "0.2.0"
+
+
+def test_case_initial_v2_rejects_profile_binding_id_collision_without_publication(
+    tmp_path: Path,
+) -> None:
+    request = _case_v2_request(
+        tmp_path,
+        request_id="binding-id-collision",
+        output_name="binding-id-collision-output",
+    )
+    run_ref = next(
+        item
+        for item in request.object_inputs
+        if item.role == "evidence_sufficiency_run_result"
+    )
+    run_payload = json.loads(run_ref.path.read_text())
+    profile = run_payload["profiles"][0]
+    profile_ref = f"{profile['profile_id']}@{profile['profile_version']}"
+    collision_digest = hashlib.sha256(
+        (
+            f"{run_payload['result_id']}@{run_payload['result_version']}|"
+            f"{profile_ref}"
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    collision_id = f"sufficiency-profile-binding:{collision_digest}"
+
+    bundle_ref = next(
+        item for item in request.object_inputs if item.role == "compilation_bundle"
+    )
+    bundle_payload = json.loads(bundle_ref.path.read_text())
+    for candidate in bundle_payload["candidate_records"]:
+        candidate["sufficiency_profile_input_id"] = collision_id
+    bundle_sha256 = _write(bundle_ref.path, bundle_payload)
+    request = request.model_copy(
+        update={
+            "object_inputs": [
+                item.model_copy(update={"input_id": collision_id})
+                if item.role == "evidence_sufficiency_run_result"
+                else item.model_copy(update={"sha256": bundle_sha256})
+                if item.role == "compilation_bundle"
+                else item
+                for item in request.object_inputs
+            ],
+        }
+    )
+    spec = _spec()
+
+    eligibility = adapter.check_eligibility(request, spec)
+    run = adapter.run(request, spec)
+
+    assert not eligibility.eligible
+    assert eligibility.reason_codes == [
+        "sufficiency_profile_binding_id_collision"
+    ]
+    assert run.execution_state is ExecutionState.FAILED
+    assert run.reason_codes == ["sufficiency_profile_binding_id_collision"]
+    assert run.result is None and run.artifacts == []
+    assert not request.output_dir.exists()
+
+
+def test_case_append_v2_reuses_canonical_run_with_exact_base_binding(
+    tmp_path: Path,
+) -> None:
+    initial = _run_request(
+        _case_v2_request(
+            tmp_path, request_id="case-v2-initial", output_name="case-v2-initial-output"
+        )
+    )
+    assert initial.execution_state is ExecutionState.SUCCEEDED
+    initial_root = initial.request.output_dir / initial.run_id
+    manifest_path = initial_root / "case_evidence_graph_manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    prior_records = json.loads((initial_root / "evidence_records.json").read_text())[
+        "records"
+    ]
+    prior_requirements = json.loads(
+        (initial_root / "evidence_requirements.json").read_text()
+    )["requirements"]
+    append_bundle = _bundle(
+        prior_records=prior_records,
+        prior_requirements=prior_requirements,
+        base_graph_ref={
+            "graph_id": manifest["graph_id"],
+            "graph_version": manifest["graph_version"],
+            "manifest_sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+        },
+    )
+    append = _run_request(
+        _case_v2_request(
+            tmp_path,
+            bundle=append_bundle,
+            request_id="case-v2-append",
+            output_name="case-v2-append-output",
+            base_manifest_path=manifest_path,
+        )
+    )
+
+    assert append.execution_state is ExecutionState.SUCCEEDED
+    assert append.result["graph_version"] == 2
+
+
+def test_comparison_initial_v2_consumes_two_canonical_runs(
+    tmp_path: Path,
+) -> None:
+    bundle, runs = _comparison_v2_inputs(_comparison_bundle())
+    request = _request(
+        tmp_path,
+        bundle=bundle,
+        request_id="comparison-v2-initial",
+        output_name="comparison-v2-initial-output",
+        claim_registry=_comparison_claim_registry(),
+        sufficiency_runs=runs,
+    )
+    run = _run_request(request)
+
+    assert run.execution_state is ExecutionState.SUCCEEDED
+    final = run.request.output_dir / run.run_id
+    manifest = ComparisonEvidenceGraphManifest.model_validate_json(
+        (final / "comparison_evidence_graph_manifest.json").read_bytes()
+    )
+    assert {
+        item.sufficiency_profile_ref.object_version
+        for item in manifest.external_evidence_bindings
+    } == {"0.2.0"}
+
+
+def test_comparison_append_legacy_and_v2_bind_exact_base_graph(
+    tmp_path: Path,
+) -> None:
+    legacy_bundle = _comparison_bundle()
+    legacy_initial = adapter.run(
+        _request(
+            tmp_path,
+            bundle=legacy_bundle,
+            request_id="comparison-legacy-initial",
+            output_name="comparison-legacy-initial-output",
+            profiles=_comparison_profiles(),
+            claim_registry=_comparison_claim_registry(),
+        ),
+        _spec(),
+    )
+    assert legacy_initial.execution_state is ExecutionState.SUCCEEDED
+    legacy_root = legacy_initial.request.output_dir / legacy_initial.run_id
+    legacy_manifest_path = legacy_root / "comparison_evidence_graph_manifest.json"
+    legacy_manifest = json.loads(legacy_manifest_path.read_text())
+    legacy_append_bundle = _comparison_bundle()
+    legacy_append_bundle["base_graph_ref"] = {
+        "graph_id": legacy_manifest["graph_id"],
+        "graph_version": legacy_manifest["graph_version"],
+        "manifest_sha256": hashlib.sha256(
+            legacy_manifest_path.read_bytes()
+        ).hexdigest(),
+        "manifest_input_id": "base-manifest",
+        "record_set_input_id": "base-records",
+        "requirement_set_input_id": "base-requirements",
+    }
+    legacy_append = adapter.run(
+        _request(
+            tmp_path,
+            bundle=legacy_append_bundle,
+            request_id="comparison-legacy-append",
+            output_name="comparison-legacy-append-output",
+            profiles=_comparison_profiles(),
+            claim_registry=_comparison_claim_registry(),
+            base_manifest_path=legacy_manifest_path,
+        ),
+        _spec(),
+    )
+    assert legacy_append.execution_state is ExecutionState.SUCCEEDED
+    assert legacy_append.result["graph_version"] == 2
+
+    v2_initial_bundle, v2_initial_runs = _comparison_v2_inputs(_comparison_bundle())
+    v2_initial = _run_request(
+        _request(
+            tmp_path,
+            bundle=v2_initial_bundle,
+            request_id="comparison-v2-for-append",
+            output_name="comparison-v2-for-append-output",
+            claim_registry=_comparison_claim_registry(),
+            sufficiency_runs=v2_initial_runs,
+        )
+    )
+    assert v2_initial.execution_state is ExecutionState.SUCCEEDED
+    v2_root = v2_initial.request.output_dir / v2_initial.run_id
+    v2_manifest_path = v2_root / "comparison_evidence_graph_manifest.json"
+    v2_manifest = json.loads(v2_manifest_path.read_text())
+    v2_append_bundle, v2_append_runs = _comparison_v2_inputs(_comparison_bundle())
+    v2_append_bundle["base_graph_ref"] = {
+        "graph_id": v2_manifest["graph_id"],
+        "graph_version": v2_manifest["graph_version"],
+        "manifest_sha256": hashlib.sha256(v2_manifest_path.read_bytes()).hexdigest(),
+        "manifest_input_id": "base-manifest",
+        "record_set_input_id": "base-records",
+        "requirement_set_input_id": "base-requirements",
+    }
+    v2_append = _run_request(
+        _request(
+            tmp_path,
+            bundle=v2_append_bundle,
+            request_id="comparison-v2-append",
+            output_name="comparison-v2-append-output",
+            claim_registry=_comparison_claim_registry(),
+            base_manifest_path=v2_manifest_path,
+            sufficiency_runs=v2_append_runs,
+        )
+    )
+    assert v2_append.execution_state is ExecutionState.SUCCEEDED
+    assert v2_append.result["graph_version"] == 2
+
+
+
+def test_case_initial_v2_missing_only_creates_requirement_without_zero_record(
+    tmp_path: Path,
+) -> None:
+    missing = _missing_observation()
+    missing["source_contract_ref"] = {
+        "object_id": "measurement-spec:target",
+        "object_version": "1.0.0",
+    }
+    bundle = _bundle(candidates=[], missing=[missing])
+    request = _request(
+        tmp_path,
+        bundle=bundle,
+        request_id="case-v2-missing-only",
+        output_name="case-v2-missing-only-output",
+        family_registry=_family_registry(second_family=True),
+        claim_registry=_claim_registry(orthogonal_required=True),
+        reconciliation_registry=_reconciliation_registry(
+            orthogonal_required=True
+        ),
+        sufficiency_runs=[("sufficiency-run", _v2_run(_profile()))],
+    )
+
+    run = _run_request(request)
+
+    assert run.execution_state is ExecutionState.SUCCEEDED
+    final = run.request.output_dir / run.run_id
+    records = json.loads((final / "evidence_records.json").read_text())["records"]
+    requirements = json.loads(
+        (final / "evidence_requirements.json").read_text()
+    )["requirements"]
+    assert records == []
+    assert {item["requirement_key"] for item in requirements} == {
+        "orthogonal_channel",
+        "transcriptomic_channel",
+    }
+    assert all(item["state"] == "open" for item in requirements)
+    orthogonal = next(
+        item
+        for item in requirements
+        if item["requirement_key"] == "orthogonal_channel"
+    )
+    assert orthogonal["source_contract_ref"] == missing["source_contract_ref"]
+    assert orthogonal["satisfying_evidence_refs"] == []
+    assert all("value" not in item for item in requirements)
+
+
+def test_comparison_v2_duplicate_run_identity_fails_closed(
+    tmp_path: Path,
+) -> None:
+    bundle, runs = _comparison_v2_inputs(_comparison_bundle())
+    first = runs[0][1]
+    duplicate = runs[1][1]
+    digest = first["result_id"].rsplit(":", 1)[1]
+    duplicate["result_id"] = first["result_id"]
+    duplicate["case_summary"]["summary_id"] = (
+        f"case-evidence-readiness-summary:{digest}"
+    )
+    duplicate_profile = duplicate["profiles"][0]
+    duplicate_profile["profile_id"] = (
+        f"evidence-sufficiency-profile:{digest}:target_identity"
+    )
+    duplicate_profile["deterministic_run_ref"] = f"run-{digest}"
+    duplicate["gate_trace"][0]["profile_ref"] = duplicate_profile["profile_id"]
+    request = _request(
+        tmp_path,
+        bundle=bundle,
+        request_id="comparison-v2-duplicate-run",
+        output_name="comparison-v2-duplicate-run-output",
+        claim_registry=_comparison_claim_registry(),
+        sufficiency_runs=runs,
+    )
+
+    eligibility = adapter.check_eligibility(request, _spec())
+    run = _run_request(request)
+
+    assert eligibility.eligible is False
+    assert eligibility.reason_codes == ["duplicate_sufficiency_run_id"]
+    assert run.execution_state is ExecutionState.FAILED
+    assert run.reason_codes == ["duplicate_sufficiency_run_id"]
+    assert run.result is None and run.artifacts == []
+    assert not request.output_dir.exists()
+
+
+def test_dangling_comparison_provenance_is_partial_with_v2_run_inputs(
+    tmp_path: Path,
+) -> None:
+    bundle, runs = _comparison_v2_inputs(_comparison_bundle(dangling=True))
+    request = _request(
+        tmp_path,
+        bundle=bundle,
+        request_id="comparison-v2-dangling",
+        output_name="comparison-v2-dangling-output",
+        claim_registry=_comparison_claim_registry(),
+        sufficiency_runs=runs,
+    )
+
+    run = _run_request(request)
+
+    assert run.execution_state is ExecutionState.PARTIAL
+    assert run.reason_codes == ["individual_records_rejected"]
+    final = run.request.output_dir / run.run_id
+    rejected = json.loads((final / "rejected_records.json").read_text())["records"]
+    assert len(rejected) == 1
+    assert rejected[0]["source_kind"] == "external_case_evidence_ref"
+    assert rejected[0]["reason_codes"] == [
+        "declared_object_ref_not_found",
+        "external_evidence_claim_mapping_invalid",
+    ]
+    queries = EvidenceGraphQueries.open(
+        final / "comparison_evidence_graph_manifest.json"
+    )
+    result = queries.compare_evidence_paths(
+        comparison_id="comparison:case-a-vs-b",
+        claim_id="claim:comparison",
+    )
+    external = [
+        item
+        for item in result.nodes
+        if item["node_type"] == "EvidenceRecord"
+        and item["record_mode"] == "external_ref"
+    ]
+    assert len(external) == 1
+
+
+def test_v2_sufficiency_modes_reject_mixing_and_binding_drift(
+    tmp_path: Path,
+) -> None:
+    mixed = _case_v2_request(
+        tmp_path, request_id="mixed-v2", output_name="mixed-v2-output"
+    )
+    legacy = _request(
+        tmp_path,
+        request_id="mixed-legacy-source",
+        output_name="mixed-legacy-source-output",
+    )
+    legacy_profile = next(
+        item
+        for item in legacy.object_inputs
+        if item.role == "evidence_sufficiency_profile"
+    ).model_copy(update={"input_id": "legacy-profile"})
+    mixed = mixed.model_copy(
+        update={"object_inputs": [*mixed.object_inputs, legacy_profile]}
+    )
+    mixed_run = _run_request(mixed)
+    assert mixed_run.execution_state is ExecutionState.FAILED
+    assert "mixed_sufficiency_input_modes" in mixed_run.reason_codes
+
+    drift_bundle = _bundle()
+    drift_bundle["candidate_records"][0]["sufficiency_profile_input_id"] = (
+        "sufficiency-run"
+    )
+    drift_bundle["candidate_records"][0]["measurement_result_ref"][
+        "object_version"
+    ] = "2.0.0"
+    drift = _run_request(
+        _case_v2_request(
+            tmp_path,
+            bundle=drift_bundle,
+            request_id="binding-drift-v2",
+            output_name="binding-drift-v2-output",
+        )
+    )
+    assert drift.execution_state is ExecutionState.PARTIAL
+    assert drift.reason_codes == ["individual_records_rejected"]
+    rejected = json.loads(
+        (
+            drift.request.output_dir
+            / drift.run_id
+            / "rejected_records.json"
+        ).read_text()
+    )["records"]
+    assert rejected[0]["reason_codes"] == [
+        "declared_object_ref_not_found",
+        "sufficiency_profile_measurement_result_mismatch",
+    ]
+
+
+def test_v2_run_schema_version_checksum_and_case_set_drift_fail_closed(
+    tmp_path: Path,
+) -> None:
+    version_request = _case_v2_request(
+        tmp_path, request_id="version-drift-v2", output_name="version-drift-v2-output"
+    )
+    run_ref = next(
+        item
+        for item in version_request.object_inputs
+        if item.role == "evidence_sufficiency_run_result"
+    )
+    version_request = version_request.model_copy(
+        update={
+            "object_inputs": [
+                item.model_copy(update={"object_version": "0.1.0"})
+                if item.input_id == run_ref.input_id
+                else item
+                for item in version_request.object_inputs
+            ]
+        }
+    )
+    version_run = _run_request(version_request)
+    assert version_run.execution_state is ExecutionState.FAILED
+    assert "structured_input_schema_invalid" in version_run.reason_codes
+
+    checksum_request = _case_v2_request(
+        tmp_path,
+        request_id="checksum-drift-v2",
+        output_name="checksum-drift-v2-output",
+    )
+    checksum_ref = next(
+        item
+        for item in checksum_request.object_inputs
+        if item.role == "evidence_sufficiency_run_result"
+    )
+    checksum_ref.path.write_text(checksum_ref.path.read_text() + " ")
+    checksum_run = _run_request(checksum_request)
+    assert checksum_run.execution_state is ExecutionState.FAILED
+    assert "structured_input_checksum_mismatch" in checksum_run.reason_codes
+
+    comparison_bundle, runs = _comparison_v2_inputs(_comparison_bundle())
+    runs[1][1]["case_summary"]["product_case_ref"]["object_id"] = (
+        "product-case:wrong"
+    )
+    case_drift_request = _request(
+        tmp_path,
+        bundle=comparison_bundle,
+        request_id="case-set-drift-v2",
+        output_name="case-set-drift-v2-output",
+        sufficiency_runs=runs,
+    )
+    case_drift = _run_request(case_drift_request)
+    assert case_drift.execution_state is ExecutionState.FAILED
+    assert (
+        "structured_input_schema_invalid" in case_drift.reason_codes
+        or "sufficiency_run_case_binding_invalid" in case_drift.reason_codes
     )
 
 
@@ -3959,7 +4635,7 @@ def test_static_capacity_uses_complete_table_without_top_n_selection(
         profile=expanded,
         output_dir=tmp_path / "render",
         run_id="run-capacity",
-        tool_version="0.3.0",
+        tool_version="0.4.0",
     )
 
     table = prepared.payloads["evidence_compiler_claim_interpretation.tsv"]
@@ -3992,7 +4668,7 @@ def test_static_capacity_falls_back_when_reason_text_cannot_fit(
         profile=expanded,
         output_dir=tmp_path / "render",
         run_id="run-reason-capacity",
-        tool_version="0.3.0",
+        tool_version="0.4.0",
     )
 
     table = prepared.payloads["evidence_compiler_requirements_exclusions.tsv"]
@@ -4481,7 +5157,7 @@ def test_long_reference_labels_remain_distinguishable_in_render(tmp_path: Path) 
         profile=profile,
         output_dir=tmp_path / "render",
         run_id="run-ref-collision",
-        tool_version="0.3.0",
+        tool_version="0.4.0",
     )
     labels = [_short_ref(ref) for ref in refs]
     svg = prepared.payloads["evidence_compiler_claim_interpretation.svg"]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -89,12 +89,50 @@ def test_every_tool_exposes_a_resolvable_input_contract() -> None:
 
     assert registry.describe_input("P0-01").asset_input.max_count == 1
     assert len(registry.describe_input("P0-03").object_input_modes[0].roles) == 12
-    assert [mode.mode_id for mode in registry.describe_input("P0-09").object_input_modes] == [
+    p009_modes = registry.describe_input("P0-09").object_input_modes
+    assert [mode.mode_id for mode in p009_modes] == [
         "case_initial",
         "case_append",
         "comparison_initial",
         "comparison_append",
+        "case_initial_v2",
+        "case_append_v2",
+        "comparison_initial_v2",
+        "comparison_append_v2",
     ]
+    legacy_profile = next(
+        role
+        for role in p009_modes[0].roles
+        if role.role == "evidence_sufficiency_profile"
+    )
+    assert legacy_profile.schema_refs == [
+        "bridge://schemas/evidence-sufficiency-profile/v0.1",
+        "bridge://schemas/evidence-sufficiency-profile/v0.2",
+    ]
+    assert legacy_profile.object_versions == ["0.1.0", "0.2.0"]
+    canonical_run = next(
+        role
+        for role in p009_modes[4].roles
+        if role.role == "evidence_sufficiency_run_result"
+    )
+    assert canonical_run.schema_refs == [
+        "bridge://schemas/evidence-sufficiency-run-result/v0.2"
+    ]
+    assert (canonical_run.min_count, canonical_run.max_count) == (1, 1)
+    for mode in (p009_modes[1], p009_modes[5]):
+        base_manifest = next(
+            role for role in mode.roles if role.role == "base_graph_manifest"
+        )
+        assert base_manifest.schema_refs == [
+            "bridge://schemas/case-evidence-graph-manifest/v0.1"
+        ]
+    for mode in (p009_modes[3], p009_modes[7]):
+        base_manifest = next(
+            role for role in mode.roles if role.role == "base_graph_manifest"
+        )
+        assert base_manifest.schema_refs == [
+            "bridge://schemas/comparison-evidence-graph-manifest/v0.1"
+        ]
     assert [mode.mode_id for mode in registry.describe_input("P0-12").object_input_modes] == [
         "not_provided",
         "graft_assessment",


### PR DESCRIPTION
## What changed

- adds four canonical P0-08 run-result modes for Case and Comparison initial/append compilation
- keeps the four existing direct-profile modes compatible
- binds each EvidenceRecord to the exact accepted P0-08 wrapper and embedded profile
- routes missing evidence by wrapper, ProductCase, and claim domain; record-level source-contract validity remains compiler-owned
- fails closed on wrapper, mode, checksum, Case-set, routing ambiguity, and duplicate logical-identity errors
- isolates valid record-level provenance or contract drift as `partial`
- turns missing-only evidence into open EvidenceRequirements without numeric substitution

## Interface

P0-09 advances to package version 0.4.0. The existing Evidence Compiler result schema remains unchanged. Canonical and legacy modes cannot be mixed.

## Validation

- final P0-09, registry, and shared contracts: 267 passed
- canonical valid claim-contract missing: succeeded
- invalid source contract with a valid sibling: partial, valid sibling retained
- repository policy, diff hygiene, and publication-boundary scan: passed

## Scientific boundary

This is deterministic evidence ingestion and provenance handling. P0-09 remains candidate and creates no domain score. Engineering success does not establish biological truth, sufficiency, safety, efficacy, potency, superiority, or release eligibility.