### PR TITLE
fix: accept canonical P0-09 catalog versions and provenance

### DIFF
--- a/docs/validation/p0_09_sufficiency_v2_ingestion_v0.4.md
+++ b/docs/validation/p0_09_sufficiency_v2_ingestion_v0.4.md
@@ -71,3 +71,42 @@ This is engineering validation of deterministic ingestion, provenance,
 failure isolation and artifact behavior. It does not establish biological
 truth, evidence sufficiency, product superiority, potency, safety, efficacy or
 release eligibility. P0-09 remains `candidate`; no domain score is created.
+
+## Package 0.4.1 catalog compatibility correction
+
+Canonical upstream MeasurementSpec, MeasurementResult and ToolRun objects use
+v0.2 Schemas. The compiler previously required v0.1 catalog Schema references
+for those node types and rejected otherwise bound records with
+`declared_object_ref_not_found`.
+
+The catalog now accepts the explicit v0.1/v0.2 pair for those three types.
+Existing type, identity, version and downstream evidence checks remain active.
+Unknown Schema versions still reject the affected record. No input or result
+Schema changed. Catalog references do not contain upstream payloads: their
+Schema/content validation remains a caller responsibility.
+
+Verification:
+
+- `python -m pytest tests/test_p0_09_evidence_compiler.py -q`: 218 passed.
+- Six added regression cases exercise v0.2 acceptance and unknown-version
+  rejection for each of the three upstream object types; the existing node-role
+  confusion test and legacy-v0.1 cases remain passing.
+- A wheel was built and installed into a separate target; the installed registry
+  reports P0-09 0.4.1.
+- Repository policy and `git diff --check` passed.
+
+This correction establishes interface compatibility. It adds no biological
+validation, score, release authority or scientific-state promotion.
+
+The same compatibility correction preserves namespaced logical provenance such
+as `data-view:run-example:all-observations@0.1.0`. Previously that valid upstream
+reference caused `individual_record_schema_invalid`. One version suffix is
+validated with the existing object-version grammar; empty/compound suffixes,
+email-shaped strings, paths and credential-like values remain rejected.
+The JSON Schema still describes the same string fields and object shape.
+
+After this additional correction, the focused catalog, provenance, publication
+and Schema selection passed: 63 passed, 162 deselected. This includes a full
+compiled-record check that retains the exact versioned provenance plus six
+negative grammar/privacy cases. The wheel was rebuilt into a new installation
+target; the earlier diagnostic wheel was retained separately.

--- a/examples/agent-integration/profiles/single-product.json
+++ b/examples/agent-integration/profiles/single-product.json
@@ -806,7 +806,7 @@
     {
       "binding_id": "evidence-compiler",
       "tool_id": "P0-09",
-      "tool_version": "0.4.0",
+      "tool_version": "0.4.1",
       "request_schema_ref": "bridge://schemas/tool-request/v0.2",
       "mode_id": "case_initial_v2",
       "asset_slot_ids": [],

--- a/examples/requests/p0_09_evidence_compiler.json
+++ b/examples/requests/p0_09_evidence_compiler.json
@@ -53,5 +53,5 @@
   "random_seed": 0,
   "request_id": "example-p0-09-documentation-only",
   "tool_id": "P0-09",
-  "tool_version": "0.4.0"
+  "tool_version": "0.4.1"
 }

--- a/src/bridge/tool_packages/cards/P0-09.md
+++ b/src/bridge/tool_packages/cards/P0-09.md
@@ -8,7 +8,7 @@ Given already-computed, versioned product evidence, which atomic records support
 
 | Field | Value |
 |---|---|
-| Package version | `0.4.0` |
+| Package version | `0.4.1` |
 | Runtime state | `implemented` |
 | Scientific state | `candidate` |
 | EnvironmentSpec | `ENV-EVIDENCE-v0.2` (`health_check_passed`) |
@@ -101,7 +101,7 @@ Detailed task card: `docs/bridge_spec_v0.1/evidence_compiler_task_card.md`.
 |---|---|---:|---|
 | `request_id` | string | yes | Caller trace only; excluded from semantic identity |
 | `tool_id` | literal `P0-09` | yes | Must select this package |
-| `tool_version` | literal `0.4.0` or null | no | If present, must match exactly |
+| `tool_version` | literal `0.4.1` or null | no | If present, must match exactly |
 | `output_dir` | absolute path | yes | Deployment-owned destination; may not contain any structured input |
 | `assets` | array | yes | Must be empty; expression assets are outside P0-09 |
 | `measurement_spec_ref` | null | yes | MeasurementSpec belongs inside each candidate/object catalog |
@@ -252,7 +252,7 @@ Reconciliation reasons include contract/spec not frozen or mismatched, sufficien
 {
   "request_id": "example-p0-09",
   "tool_id": "P0-09",
-  "tool_version": "0.4.0",
+  "tool_version": "0.4.1",
   "output_dir": "/absolute/output",
   "assets": [],
   "measurement_spec_ref": null,
@@ -289,3 +289,15 @@ Reconciliation reasons include contract/spec not frozen or mismatched, sufficien
   "reason_codes": []
 }
 ```
+
+### Catalog Schema compatibility
+
+MeasurementSpec, MeasurementResult and ToolRun catalog entries accept the explicit
+v0.1 and v0.2 Schema references. Node types and exact object ID/version bindings
+remain checked; unknown versions are rejected for the affected candidate. Catalog
+entries carry references and content hashes, not full upstream object payloads.
+Callers validate those payloads against their declared public Schema.
+
+Versioned logical references such as `data-view:run-example:all-observations@0.1.0`
+are preserved in provenance. The suffix must satisfy the existing object-version
+grammar; path and credential guards still apply.

--- a/src/bridge/tool_packages/p0_09_evidence_compiler/README.md
+++ b/src/bridge/tool_packages/p0_09_evidence_compiler/README.md
@@ -19,6 +19,15 @@ package.
 - **Boundary:** it compiles existing facts, preserves history and explicit
   missingness, and never reruns biology, majority-votes tools or verifies claims.
 
+## Upstream catalog compatibility
+
+Catalog entries for MeasurementSpec, MeasurementResult and ToolRun accept the
+published v0.1 and v0.2 Schema references. Node types and exact object ID/version
+bindings remain required; other Schema versions are rejected for the affected
+record. A catalog entry contains a content hash and reference, not the complete
+upstream object. The caller remains responsible for validating that object's
+content against its declared Schema before materializing the compilation bundle.
+
 ## Documentation
 
 - [Implementation, software, calls and current evidence](../../../../docs/tool-packages.md#p0-09)
@@ -29,3 +38,7 @@ package.
 
 Use `bridge-tool describe P0-09` for the installed version, schemas, environment
 and registered method IDs.
+
+Versioned logical references such as `data-view:run-example:all-observations@0.1.0`
+are preserved in provenance. The suffix must satisfy the existing object-version
+grammar; path and credential guards still apply.

--- a/src/bridge/tool_packages/p0_09_evidence_compiler/compiler.py
+++ b/src/bridge/tool_packages/p0_09_evidence_compiler/compiler.py
@@ -449,19 +449,28 @@ def logical_key_hash(logical_key: str) -> str:
     return hashlib.sha256(logical_key.encode("utf-8")).hexdigest()
 
 
-EXPECTED_CATALOG_SCHEMAS: dict[GraphNodeType, str] = {
-    GraphNodeType.PRODUCT_CASE: "bridge://schemas/product-case/v0.1",
-    GraphNodeType.PRODUCT_DEFINITION_CARD: "bridge://schemas/product-definition-card/v0.1",
-    GraphNodeType.SAMPLE: "bridge://schemas/sample/v0.1",
-    GraphNodeType.PREPARATION: "bridge://schemas/preparation/v0.1",
-    GraphNodeType.MEASUREMENT_SPEC: "bridge://schemas/measurement-spec/v0.1",
-    GraphNodeType.SCORE_CONTRACT: "bridge://schemas/score-contract/v0.1",
-    GraphNodeType.TOOL_RUN: "bridge://schemas/tool-run/v0.1",
-    GraphNodeType.MEASUREMENT_RESULT: "bridge://schemas/measurement-result/v0.1",
-    GraphNodeType.REFERENCE_SNAPSHOT: "bridge://schemas/reference-snapshot/v0.1",
-    GraphNodeType.PRIOR_SNAPSHOT: "bridge://schemas/prior-snapshot/v0.1",
-    GraphNodeType.ARTIFACT: "bridge://schemas/artifact/v0.1",
-    GraphNodeType.COMPARISON_RECORD: "bridge://schemas/comparison-record/v0.1",
+EXPECTED_CATALOG_SCHEMAS: dict[GraphNodeType, tuple[str, ...]] = {
+    GraphNodeType.PRODUCT_CASE: ("bridge://schemas/product-case/v0.1",),
+    GraphNodeType.PRODUCT_DEFINITION_CARD: ("bridge://schemas/product-definition-card/v0.1",),
+    GraphNodeType.SAMPLE: ("bridge://schemas/sample/v0.1",),
+    GraphNodeType.PREPARATION: ("bridge://schemas/preparation/v0.1",),
+    GraphNodeType.MEASUREMENT_SPEC: (
+        "bridge://schemas/measurement-spec/v0.1",
+        "bridge://schemas/measurement-spec/v0.2",
+    ),
+    GraphNodeType.SCORE_CONTRACT: ("bridge://schemas/score-contract/v0.1",),
+    GraphNodeType.TOOL_RUN: (
+        "bridge://schemas/tool-run/v0.1",
+        "bridge://schemas/tool-run/v0.2",
+    ),
+    GraphNodeType.MEASUREMENT_RESULT: (
+        "bridge://schemas/measurement-result/v0.1",
+        "bridge://schemas/measurement-result/v0.2",
+    ),
+    GraphNodeType.REFERENCE_SNAPSHOT: ("bridge://schemas/reference-snapshot/v0.1",),
+    GraphNodeType.PRIOR_SNAPSHOT: ("bridge://schemas/prior-snapshot/v0.1",),
+    GraphNodeType.ARTIFACT: ("bridge://schemas/artifact/v0.1",),
+    GraphNodeType.COMPARISON_RECORD: ("bridge://schemas/comparison-record/v0.1",),
 }
 
 
@@ -474,7 +483,7 @@ def _catalog_binding_matches(
     return bool(
         item is not None
         and item.node_type in allowed_types
-        and item.schema_ref == EXPECTED_CATALOG_SCHEMAS.get(item.node_type)
+        and item.schema_ref in EXPECTED_CATALOG_SCHEMAS.get(item.node_type, ())
     )
 
 

--- a/src/bridge/tool_packages/p0_09_evidence_compiler/models.py
+++ b/src/bridge/tool_packages/p0_09_evidence_compiler/models.py
@@ -183,9 +183,18 @@ def publication_ref(value: str) -> str:
     """
 
     value = _strip(value)
-    if not PUBLICATION_REF_PATTERN.fullmatch(value):
-        raise ValueError("published references must be scheme- or identifier-shaped")
-    return value
+    if PUBLICATION_REF_PATTERN.fullmatch(value):
+        return value
+    identifier, separator, version = value.rpartition("@")
+    if (
+        separator
+        and ":" in identifier
+        and "://" not in identifier
+        and PUBLICATION_REF_PATTERN.fullmatch(identifier)
+    ):
+        publication_version(version)
+        return value
+    raise ValueError("published references must be scheme- or identifier-shaped")
 
 
 def _unique(values: list[Any], field_name: str) -> list[Any]:

--- a/src/bridge/tool_packages/specs/p0_09.yaml
+++ b/src/bridge/tool_packages/specs/p0_09.yaml
@@ -1,6 +1,6 @@
 tool_id: P0-09
 name: Evidence Compiler & Reconciler
-version: 0.4.0
+version: 0.4.1
 summary: Compile atomic evidence and reconcile conflicts by versioned rules.
 implementation_state: implemented
 scientific_status: candidate

--- a/tests/test_p0_09_evidence_compiler.py
+++ b/tests/test_p0_09_evidence_compiler.py
@@ -25,6 +25,7 @@ from bridge.tool_packages.p0_08_evidence_sufficiency.models import (
 )
 from bridge.tool_packages.p0_09_evidence_compiler.models import (
     PUBLIC_SCHEMA_MODELS,
+    publication_ref,
     BaseGraphRef,
     ClaimRequirementSpec,
     EvidenceCandidate,
@@ -123,7 +124,7 @@ def _spec() -> ToolPackageSpecV2:
     return ToolPackageSpecV2(
         tool_id="P0-09",
         name="Evidence Compiler & Reconciler",
-        version="0.4.0",
+        version="0.4.1",
         summary="Compile atomic evidence and reconcile conflicts by versioned rules.",
         implementation_state=ImplementationState.IMPLEMENTED,
         scientific_status="candidate",
@@ -1012,7 +1013,7 @@ def _request(
     return ToolRequestV2(
         request_id=request_id,
         tool_id="P0-09",
-        tool_version="0.4.0",
+        tool_version="0.4.1",
         output_dir=(tmp_path / output_name).resolve(),
         assets=[],
         measurement_spec_ref=None,
@@ -1794,7 +1795,7 @@ def test_v1_adapter_invocation_has_one_stable_v2_reason(tmp_path: Path) -> None:
     request = ToolRequest(
         request_id="p0-09-v1",
         tool_id="P0-09",
-        tool_version="0.4.0",
+        tool_version="0.4.1",
         output_dir=(tmp_path / "output").resolve(),
     )
     eligibility = adapter.check_eligibility(request, _spec())  # type: ignore[arg-type]
@@ -2311,6 +2312,59 @@ def test_prior_history_from_another_product_case_fails_without_artifacts(
     assert run.reason_codes == ["prior_history_invalid"]
     assert run.result is None and run.artifacts == []
     assert not request.output_dir.exists()
+
+
+@pytest.mark.parametrize("schema_version", ["v0.2", "v9.9"])
+@pytest.mark.parametrize("schema_name", ["measurement-spec", "measurement-result", "tool-run"])
+def test_catalog_checks_supported_upstream_schema_versions(
+    tmp_path: Path, schema_name: str, schema_version: str
+) -> None:
+    bundle = _bundle()
+    catalog_entry = next(
+        item for item in bundle["object_catalog"]
+        if item["schema_ref"] == f"bridge://schemas/{schema_name}/v0.1"
+    )
+    catalog_entry["schema_ref"] = f"bridge://schemas/{schema_name}/{schema_version}"
+
+    run = _run(tmp_path, bundle=bundle)
+    final = run.request.output_dir / run.run_id
+    records = json.loads((final / "evidence_records.json").read_text())["records"]
+    rejected = json.loads((final / "rejected_records.json").read_text())["records"]
+    if schema_version == "v0.2":
+        assert len(records) == 1
+        assert rejected == []
+    else:
+        assert records == []
+        assert rejected[0]["reason_codes"] == ["declared_object_ref_not_found"]
+
+
+def test_versioned_data_view_provenance_is_preserved(tmp_path: Path) -> None:
+    bundle = _bundle()
+    reference = "data-view:run-example:all-observations@0.1.0"
+    bundle["candidate_records"][0]["provenance_refs"] = [reference]
+
+    run = _run(tmp_path, bundle=bundle)
+    final = run.request.output_dir / run.run_id
+    records = json.loads((final / "evidence_records.json").read_text())["records"]
+
+    assert run.execution_state is ExecutionState.SUCCEEDED
+    assert records[0]["provenance_refs"] == [reference]
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        "data-view:example@",
+        "data-view:example@0.1.0/extra",
+        "data-view:example@0.1.0@other",
+        "user@example.org",
+        "data-view:example@/private/input",
+        "data-view:example@sk-" + "a" * 24,
+    ],
+)
+def test_versioned_provenance_keeps_strict_publication_guard(reference: str) -> None:
+    with pytest.raises(ValueError):
+        publication_ref(reference)
 
 
 def test_catalog_node_role_confusion_rejects_only_the_candidate(tmp_path: Path) -> None:
@@ -4714,7 +4768,7 @@ def test_static_capacity_uses_complete_table_without_top_n_selection(
         profile=expanded,
         output_dir=tmp_path / "render",
         run_id="run-capacity",
-        tool_version="0.4.0",
+        tool_version="0.4.1",
     )
 
     table = prepared.payloads["evidence_compiler_claim_interpretation.tsv"]
@@ -4747,7 +4801,7 @@ def test_static_capacity_falls_back_when_reason_text_cannot_fit(
         profile=expanded,
         output_dir=tmp_path / "render",
         run_id="run-reason-capacity",
-        tool_version="0.4.0",
+        tool_version="0.4.1",
     )
 
     table = prepared.payloads["evidence_compiler_requirements_exclusions.tsv"]
@@ -5236,7 +5290,7 @@ def test_long_reference_labels_remain_distinguishable_in_render(tmp_path: Path) 
         profile=profile,
         output_dir=tmp_path / "render",
         run_id="run-ref-collision",
-        tool_version="0.4.0",
+        tool_version="0.4.1",
     )
     labels = [_short_ref(ref) for ref in refs]
     svg = prepared.payloads["evidence_compiler_claim_interpretation.svg"]


### PR DESCRIPTION
## Problem and change

Canonical upstream measurements were rejected because the P0-09 object catalog recognized only v0.1 Schema references. Versioned logical provenance such as `data-view:example@0.1.0` was also rejected.

P0-09 0.4.1 accepts the explicit supported v0.1/v0.2 Schema pairs and preserves validated version suffixes in logical provenance. Unknown versions, wrong node types, paths and credential-shaped references remain rejected. The integration profile now selects the matching package version.

## Verification

- P0-09 module suite passed for catalog compatibility; relevant provenance, privacy and Schema tests passed after the second correction.
- Installed-wheel integration tests and all three profiles passed; generated and installed Schemas match.
- Actual upstream-object ingestion confirms both compatibility corrections.
- Repository policy and whitespace checks passed.

No scientific values, interpretation rules, scores or release permissions change.