### PR TITLE
feat: add private conversational Web preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install build
-          python -m pip install ".[qc,test,freeze,evidence,target-regional,developmental,process]"
+          python -m pip install ".[qc,test,freeze,evidence,target-regional,developmental,process,web]"
 
       - name: Build and install wheel
         run: |
@@ -58,6 +58,20 @@ jobs:
 
       - name: Run tests
         run: python -m pytest -q
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Check Web preview
+        working-directory: web
+        run: |
+          npm ci
+          npm test
+          npm run build
 
       - name: Verify tool discovery
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,12 +43,14 @@ BRIDGE 采用“代码、稳定文档、临时计划同步演进”的协作方�
 
 ## 仓库地图
 
-当前仓库的 `main` 实现的是 BRIDGE 科学智能体的确定性 P0 工具底座，
-不是完整的对话式产品。Agent/Web/任务编排层通过稳定合同消费这些工具。
+当前仓库提供 BRIDGE 科学智能体的确定性 P0 工具底座，以及支持对话式输入质控
+和明确审批的私有 Web preview。完整工具链的 Agent 输入构造仍在开发中。
 
 | 路径 | 职责 |
 |---|---|
 | `src/bridge/toolkit/` | 公共对象、Registry、运行器、产物与知识检索 |
+| `src/bridge/web/` | 私有对话、上传、审批与现有 SDK 执行接入；不修改科学工具语义 |
+| `web/` | 对话与真实工具产物的浏览器界面 |
 | `src/bridge/tool_packages/` | 12 个高层科学工具包及其 Spec、Tool Card 和包内资源；底层方法不直接暴露给 Agent |
 | `src/bridge/resources/schemas/` | 随 Python 包发布的对外 JSON Schema；语义变更必须版本化 |
 | `knowledge/` | 方法目录策展、来源核验、当前 P0 短名单与知识快照重建输入 |

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Registered P0 tools produce versioned measurements and evidence records.
 | Area | Current status |
 |---|---|
 | P0 tool packages | 12/12 implemented and callable |
-| Agent orchestration | In development |
-| Web interface | Planned |
+| Agent orchestration | Conversational intake and approved input QC; full chain in development |
+| Web interface | [Private preview](docs/web-preview.md) |
 | Scientific validation | In progress |
 
 ## Quickstart
@@ -77,6 +77,7 @@ current scope.
 ## Documentation
 
 - [Product requirements](docs/BRIDGE_PRD.md)
+- [Web preview](docs/web-preview.md)
 - [Agent integration](docs/agent-integration.md)
 - [P0 Tool Packages](docs/tool-packages.md)
 - [Scientific specifications](docs/bridge_spec_v0.1/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,10 @@ evidence you need.
 > [!NOTE]
 > **Product and current stage:** BRIDGE's final product is a scientific
 > evaluation Agent. The current `main` branch provides its deterministic P0 tool
-> layer: all 12 packages are executable engineering candidates. The end-to-end
-> Agent/Web experience is not yet integrated. A shared visualization data
-> contract and figure registry are available. P0-01 provides four
+> layer: all 12 packages are executable engineering candidates. A private
+> [Web preview](web-preview.md) supports conversational input QC and approved
+> execution; full-chain Agent construction remains in development. A shared
+> visualization data contract and figure registry are available. P0-01 provides four
 > `typed_candidate` figure components, alongside two compatibility
 > `legacy_untyped` components; P0-03 provides two typed candidate figures for
 > product-role/regional-state composition and source-separated reference support;
@@ -72,6 +73,7 @@ the documentation drift. Do not infer current behavior from an overview page.
 - [Product and scientific principles](product-principles.md)
 - [Visualization system](BRIDGE_PRD.md#66-visualization-composer-与-web-交互)
 - [Agent team integration](agent-integration.md)
+- [Web preview and private deployment](web-preview.md)
 - [Privacy and provenance](privacy-and-provenance.md)
 
 ### Current P0 tool layer

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -93,3 +93,18 @@ the scientific `ProductCase` contract. Workflow success describes execution
 only and does not change evidence state, scientific readiness or release status.
 Model-provider integration, distributed execution and authentication remain
 outside this core.
+
+## 2026-09-05: Keep The First Web Preview Bounded
+
+The private Web preview adds conversation, uploaded-file intake and explicit
+approval around the existing input-QC planner and local workflow. It does not
+construct the scientific contracts required for every downstream P0 package.
+Browser results are registered tool-owned artifacts, not model-generated
+measurements. Numerical results and raw matrices are excluded from provider
+context by default.
+
+Deployment trust for an administrator-owned shared ancestor is explicit,
+startup-only and pinned to its path, owner and filesystem identity. Default
+private-path ownership checks remain strict; trust does not propagate to
+descendants or relax symlink, permission or replacement checks. This is a
+single-operator deployment boundary, not a multi-tenant authorization model.

--- a/docs/privacy-and-provenance.md
+++ b/docs/privacy-and-provenance.md
@@ -47,3 +47,26 @@ registered blocking finding is not proof that a separate renderer is XSS-safe.
 Repository fixtures are synthetic, public, licensed or irreversibly de-identified.
 Each fixture records source class, intended tests and checksum. A fixture validates
 only the behavior it explicitly covers.
+
+## Private Runtime Ancestor Trust
+
+Private storage rejects ancestors not owned by the process user or root by
+default. A deployment operator may call
+`bridge.storage.private_paths.configure_trusted_ancestors(ancestors)` at process
+startup, before any private-path I/O. The mapping has exact absolute `Path` keys
+and `(uid, device, inode)` integer tuples, obtained and approved out of band.
+There is no automatic environment discovery, request-level override or runtime
+trust expansion. Configuration is copied, validated and locked; changing it
+requires a process restart. Repeating the identical configuration revalidates it.
+
+This narrowly trusts the specified directory administrator, not every ancestor
+or descendant. Every traversal uses descriptor-relative no-follow opens and
+rechecks each configured identity. Replacements, symlinks, identity changes and
+group/world-writable trusted ancestors (including sticky ones) are rejected.
+Other ancestors retain the default guard. Final private directories must still
+be owned by the process user and inaccessible to group/other; files retain the
+owner, regular-file and no-follow checks. The guard never changes ancestor
+permissions or ownership. Explicitly trusted administrators and root remain in
+the deployment trust boundary; this is not isolation from them or a public
+multi-tenant security model. Deployment paths and identity pins remain outside
+repository content and HTTP/model inputs.

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -27,6 +27,7 @@ lineage checks do not sign the biological FreezeGate.
 
 ## Shared Runtime and Repository Evidence
 
+- [Private conversational Web preview, 2026-09-05](web_preview_20260905.md)
 - [Visualization data contract, 2026-08-28](visualization_data_contract_20260828.md)
 - [Repository readability validation, 2026-08-25](repository_readability_20260825.md)
 - [Structured tool runtime contracts, 2026-08-13](tool_runtime_structured_contracts_20260813.md)

--- a/docs/validation/web_preview_20260905.md
+++ b/docs/validation/web_preview_20260905.md
@@ -1,0 +1,85 @@
+# Private conversational Web preview — 2026-09-05
+
+## Question and scope
+
+Can a researcher upload an expression file, declare its assay and count
+semantics, approve a plan, and inspect the actual input-QC evidence within a
+persistent conversation?
+
+The Web route covers P0-01 input QC. Existing CLI/SDK packages remain callable;
+this release does not construct the additional scientific objects needed for
+a full-chain product evaluation.
+
+## Evidence and observations
+
+A private, authorized real-data browser scenario exercised login, conversation,
+upload, clarification, exact-plan approval, actual P0-01 execution, figure and
+table display, evidence downloads, model follow-up, page refresh and a narrow
+viewport. The final fresh-session scenario passed without API mocks or browser
+page errors. All registered download contents matched their private receipts;
+workflow events recorded submission, claim and successful execution.
+
+Scientific inputs, screenshots, transcripts, resource identities, checksums,
+measurements and deployment details remain outside the repository. Missing
+biological design was not filled in. A successful QC execution does not mean
+that every QC metric is available or that a product has passed an assessment.
+
+During validation, a provider returned an empty successful HTTP response when
+a second system message followed the user turn. Keeping one leading system
+message with the same status context restored real follow-up responses. A
+request-order regression test now covers this compatibility requirement.
+Provider failures remain explicit; no canned model reply is substituted.
+
+## Engineering verification
+
+| Check | Evidence |
+|---|---|
+| Service and exact ancestor trust | 104 focused server tests passed |
+| Browser client | 16 tests and production build passed |
+| Installed Python wheel | Service imported from the installed package, not the source checkout |
+| Live browser flow | Final fresh conversation and actual QC flow passed; desktop and narrow layout inspected |
+| Artifacts and events | Registered content integrity and persisted workflow transitions checked |
+| Repository gates | Policy, knowledge, figure registry and whitespace checks passed on the integrated server tree |
+| Full regression | The integration predecessor passed the full server suite; changed service/storage and client paths were retested after review fixes. Required CI runs the full suite on the PR revision before merge. |
+
+Reproduce public engineering checks with the documented Python and Node setup:
+
+~~~bash
+python -m pytest -q
+python -m pytest tests/test_web_service.py tests/test_private_path_trust.py -q
+npm --prefix web ci
+npm --prefix web test
+npm --prefix web run build
+python -m build --wheel
+python -m bridge.toolkit.cli list --json
+python -m bridge.toolkit.cli knowledge validate
+python -m bridge.toolkit.cli figures validate
+python scripts/check_repository.py
+git diff --check
+~~~
+
+The private real-data browser scenario is separate from synthetic automated
+tests. Its pass establishes this interaction path, not broad biological
+performance or arbitrary-provider reliability.
+
+Storage, service and client changes received independent scoped reviews.
+The final integration review found no Critical or Important issue. Merge is
+conditional on the required checks for the exact PR head.
+
+## Limits and next work
+
+- This is a single-operator private preview, not a public multi-user service.
+- Only H5AD uploads and explicit raw-count/assay declarations are supported.
+  No biological replicate or reference metadata is inferred.
+- The provider receives conversation and minimal execution status. It does
+  not receive the uploaded matrix or tool-owned biological measurements.
+  Model replies are not passed through P0-10 claim verification in this preview.
+- Actual numerical evidence lives in tool-owned artifacts. Path-redacted JSON
+  display downloads are not canonical downstream inputs.
+- All scientific methods remain candidate/shadow; scores and scientific
+  release status are unchanged.
+- Full-chain input construction and evidence-grounded model interpretation
+  remain follow-up work, with separate data-sharing and scientific controls.
+
+See [Web setup and interface](../web-preview.md) and
+[Agent integration](../agent-integration.md).

--- a/docs/web-preview.md
+++ b/docs/web-preview.md
@@ -1,0 +1,123 @@
+# Web preview
+
+BRIDGE has a private, single-operator conversational preview. Upload an H5AD,
+declare its assay and counts layer, review an input-QC plan, then confirm it.
+The existing P0-01 package produces the figures and artifacts shown alongside
+the conversation.
+
+This first Web release covers input QC. The 12 P0 packages remain available
+through their existing CLI and SDK; the Web interface does not yet construct
+the scientific inputs needed to execute the full tool chain. Missing sample
+design, product definitions and reference contracts are not invented.
+
+The preview supports explicit `scRNA-seq` or `snRNA-seq` declarations and raw
+counts in `X` or `layers/counts`. Uploads are limited to 128 MiB per file and
+eight files per conversation. The HDF5 structure is checked before planning;
+separate CSV/JSON metadata uploads are not supported in this first preview.
+No metadata table is automatically joined or treated as verified sample design.
+
+## Start a private instance
+
+Use Python 3.12 and Node.js 22. Install the optional service dependencies and
+build the client:
+
+~~~bash
+python -m pip install ".[qc,web]"
+npm --prefix web ci
+npm --prefix web run build
+~~~
+
+Configure the service outside the checkout. Keep credentials in an
+operator-owned private environment file, never in Git or the browser bundle.
+
+| Setting | Meaning |
+|---|---|
+| `BRIDGE_WEB_STORAGE` | Absolute private directory for sessions, uploads, plans and workflow evidence |
+| `BRIDGE_WEB_TOKEN` | Random operator login secret, at least 24 characters |
+| `BRIDGE_WEB_MODEL_BASE_URL` | OpenAI-compatible provider base URL; use HTTPS for external providers |
+| `BRIDGE_WEB_MODEL` | Provider model identifier |
+| `BRIDGE_WEB_MODEL_API_KEY` | Server-only provider credential |
+| `BRIDGE_WEB_STATIC_DIR` | Absolute path to the built `web/dist` directory |
+| `BRIDGE_WEB_ORIGIN` | Exact browser origin; defaults to `http://127.0.0.1:8765` |
+| `BRIDGE_WEB_PORT` | Loopback port; defaults to `8765` |
+| `BRIDGE_WEB_TRUSTED_ANCESTORS` | Optional startup-only JSON mapping from explicitly approved ancestor paths to `[uid, device, inode]` pins |
+
+With these variables supplied by the deployment environment:
+
+~~~bash
+python -m bridge.web
+~~~
+
+The service binds to loopback. Access it through an authenticated encrypted
+tunnel or an operator-managed HTTPS reverse proxy. Do not expose it as an
+unauthenticated public service. It is not a multi-user authorization system.
+
+The default private-path policy accepts root-owned or operator-owned safe
+ancestors and requires operator-owned private leaves. A shared mount owned by
+another administrator requires explicit trust approval and exact identity
+pins. Configure this before private I/O; changing trust requires a restart.
+The setting does not relax symlink, replacement, writable-ancestor or
+private-leaf checks. See [privacy and provenance](privacy-and-provenance.md).
+
+## A typical conversation
+
+1. Log in with the operator token and create an analysis.
+2. Upload an H5AD. The browser lists the accepted file; the service stores a
+   checksummed copy under a generated identity.
+3. Tell BRIDGE the assay and which matrix contains raw counts. The Agent asks
+   for clarification when those declarations are missing.
+4. Review the proposed input-QC plan. Confirmation is bound to its exact
+   digest; sending a chat message alone never approves execution.
+5. Inspect actual figures, tables, evidence and downloads. Refreshing the page
+   restores the session.
+6. Ask follow-up questions. The conversation retains context; the tool outputs
+   remain the source of numerical evidence.
+
+Counts declarations do not establish sample, capture, preparation or batch
+relationships. Unknown biological design remains unknown. A successful tool
+run can still have limited readiness or unavailable measurements.
+
+## Interface and ownership
+
+The React client uses [assistant-ui's external store runtime](https://www.assistant-ui.com/docs/runtimes/custom/external-store).
+The server owns session state, approvals and tool execution; assistant-ui does
+not act as a second workflow engine.
+
+| Route | Purpose |
+|---|---|
+| `POST /api/login`, `POST /api/logout` | Establish or revoke the operator cookie |
+| `GET /api/sessions`, `POST /api/sessions` | List or create analyses |
+| `GET /api/sessions/{id}` | Read messages, uploads, plan status and artifact index |
+| `POST /api/sessions/{id}/uploads` | Accept a bounded multipart upload |
+| `POST /api/sessions/{id}/messages` | Submit one conversation turn |
+| `POST /api/sessions/{id}/approve` | Approve the exact proposed plan ID and digest |
+| `GET /api/sessions/{id}/artifacts/{artifact_id}` | Retrieve a registered artifact under authentication |
+| `GET /api/sessions/{id}/transcript` | Download the conversation |
+
+The Web layer uses `PlanBuilder`, immutable approved requests,
+`ToolExecutionPipeline` and `LocalWorkflowExecutor` with SQLite events.
+It does not execute model-generated commands or invoke scientific libraries
+outside the registered package.
+
+## Privacy and interpretation
+
+- Provider requests contain conversation text and a small status context, not
+  uploaded matrices, private file paths or tool-owned biological measurements.
+  Avoid entering confidential identifiers or secrets into chat text.
+- The model can request a bounded QC plan or reply. It cannot approve a plan,
+  change scientific values or select arbitrary filesystem paths. Model replies
+  are not P0-10-verified reports; numerical evidence belongs to the tool artifacts.
+- Artifacts are private downloads. Downloading them is not P0-11 public-safe
+  export, release approval or an assertion that they contain no private data.
+- JSON downloads labeled `.display-redacted.json` are presentation copies
+  with private paths removed. They are not byte-identical canonical tool
+  inputs; the private receipt retains the original artifact ID and digest.
+  Use the original server-owned contracts for downstream execution.
+- `candidate/shadow` methods and `domain_score=null` are unchanged.
+  No clinical, safety, potency or GMP conclusions are authorized.
+- Provider errors and interrupted work are explicit. Restarting the service
+  must not silently replay a previously running analysis.
+
+See [tool packages](tool-packages.md) for scientific interfaces,
+[Agent integration](agent-integration.md) for full-chain ownership, and the
+[validation record](validation/web_preview_20260905.md) for the tested preview scope.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+web = [
+  "fastapi>=0.115,<1",
+  "uvicorn>=0.32,<1",
+  "httpx>=0.28,<1",
+  "python-multipart>=0.0.20,<1",
+]
 qc = [
   "anndata>=0.11,<0.13",
   "h5py>=3.11,<4",

--- a/scripts/check_repository.py
+++ b/scripts/check_repository.py
@@ -12,7 +12,7 @@ from bridge.toolkit.registry import ToolRegistry
 
 
 ROOT = Path(__file__).resolve().parents[1]
-TEXT_SUFFIXES = {".css", ".html", ".json", ".jsonl", ".md", ".py", ".toml", ".tsv", ".txt", ".yaml", ".yml"}
+TEXT_SUFFIXES = {".css", ".html", ".json", ".jsonl", ".md", ".py", ".toml", ".ts", ".tsx", ".tsv", ".txt", ".yaml", ".yml"}
 EXCLUDED_PARTS = {
     ".git",
     ".pytest_cache",
@@ -21,6 +21,7 @@ EXCLUDED_PARTS = {
     "build",
     "dist",
     "private_assets",
+    "node_modules",
     "run_artifacts",
     "tmp",
     "venv",
@@ -78,6 +79,47 @@ AGENT_RUNTIME_FILES = (
     Path("tests/test_local_artifact_store.py"),
     Path("tests/test_tool_execution_pipeline.py"),
     Path("tests/test_workflow_runtime.py"),
+)
+# Bounded, reviewed Web surface; build products and dependencies are not sources.
+WEB_PREVIEW_FILES = (
+    Path("src/bridge/web/__init__.py"),
+    Path("src/bridge/web/__main__.py"),
+    Path("src/bridge/web/app.py"),
+    Path("src/bridge/web/provider.py"),
+    Path("tests/test_private_path_trust.py"),
+    Path("tests/test_web_service.py"),
+    Path("web/.gitignore"),
+    Path("web/README.md"),
+    Path("web/index.html"),
+    Path("web/package-lock.json"),
+    Path("web/package.json"),
+    Path("web/src/App.tsx"),
+    Path("web/src/api.ts"),
+    Path("web/src/components/Conversation.tsx"),
+    Path("web/src/components/LoginScreen.tsx"),
+    Path("web/src/components/MarkdownText.tsx"),
+    Path("web/src/components/MarkdownTextImpl.tsx"),
+    Path("web/src/components/PlanCard.tsx"),
+    Path("web/src/components/ResultsPane.tsx"),
+    Path("web/src/components/Sidebar.tsx"),
+    Path("web/src/components/StatusMark.tsx"),
+    Path("web/src/main.tsx"),
+    Path("web/src/runtime/BridgeRuntimeProvider.tsx"),
+    Path("web/src/styles.css"),
+    Path("web/src/types.ts"),
+    Path("web/src/vite-env.d.ts"),
+    Path("web/tests/api.test.ts"),
+    Path("web/tests/app-polling.test.tsx"),
+    Path("web/tests/markdown-security.test.tsx"),
+    Path("web/tests/plan-card.test.tsx"),
+    Path("web/tests/results-pane.test.tsx"),
+    Path("web/tests/setup.ts"),
+    Path("web/tsconfig.app.json"),
+    Path("web/tsconfig.json"),
+    Path("web/tsconfig.node.json"),
+    Path("web/vite.config.ts"),
+    Path("docs/web-preview.md"),
+    Path("docs/validation/web_preview_20260905.md"),
 )
 AGENT_INTEGRATION_FILES = (
     Path("examples/agent-integration/profiles/comparison.json"),
@@ -335,6 +377,7 @@ def _tracked_file_budget() -> int:
     )
     return (
         TRACKED_FILE_BASELINE
+        + sum((ROOT / relative).is_file() for relative in WEB_PREVIEW_FILES)
         + p004_visualization_files
         + p005_visualization_files
         + p005_measurement_projection_files

--- a/src/bridge/storage/private_paths.py
+++ b/src/bridge/storage/private_paths.py
@@ -4,7 +4,14 @@ import errno
 import os
 import stat
 import sys
+from collections.abc import Mapping
 from pathlib import Path
+from threading import Lock
+
+
+_trusted_ancestors: dict[Path, tuple[int, int, int]] = {}
+_trust_frozen = False
+_trust_lock = Lock()
 
 
 class PrivatePathError(ValueError):
@@ -26,15 +33,64 @@ def canonical_absolute_path(path: Path) -> Path:
     return raw
 
 
+def configure_trusted_ancestors(
+    ancestors: Mapping[Path, tuple[int, int, int]],
+) -> None:
+    """Pin operator-approved ancestors before private I/O; never use request input.
+
+    Values are (uid, device, inode). Configuration is copied and validated
+    without following links or changing permissions. Once configured or used,
+    only an identical policy can be supplied again; changes require a restart.
+    """
+    global _trusted_ancestors, _trust_frozen
+    policy: dict[Path, tuple[int, int, int]] = {}
+    for path, identity in ancestors.items():
+        canonical = canonical_absolute_path(path)
+        if (
+            canonical == Path(canonical.anchor)
+            or canonical in policy
+            or not isinstance(identity, tuple)
+            or len(identity) != 3
+            or any(type(value) is not int or value < 0 for value in identity)
+        ):
+            raise PrivatePathError("trusted_ancestor_configuration_invalid")
+        policy[canonical] = identity
+    with _trust_lock:
+        if _trust_frozen and policy != _trusted_ancestors:
+            raise PrivatePathError("private_path_trust_configuration_locked")
+        for path in policy:
+            descriptor = _open_directory(path, create=False, ancestors=policy)
+            os.close(descriptor)
+        _trusted_ancestors = policy
+        _trust_frozen = True
+
+
 def open_private_directory(path: Path, *, create: bool) -> tuple[Path, int]:
+    global _trust_frozen
+    with _trust_lock:
+        _trust_frozen = True
+        ancestors = _trusted_ancestors
     canonical = canonical_absolute_path(path)
+    descriptor = _open_directory(canonical, create=create, ancestors=ancestors)
+    try:
+        _require_private_owner_directory(descriptor)
+        return canonical, descriptor
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _open_directory(
+    canonical: Path, *, create: bool, ancestors: Mapping[Path, tuple[int, int, int]],
+) -> int:
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     try:
         descriptor = os.open(canonical.anchor, flags)
     except OSError as error:
         raise PrivatePathError("private_path_anchor_invalid") from error
     try:
-        _require_safe_ancestor_directory(descriptor)
+        current = Path(canonical.anchor)
+        _require_safe_ancestor_directory(descriptor, current, ancestors)
         for component in canonical.parts[1:]:
             if create:
                 try:
@@ -48,14 +104,14 @@ def open_private_directory(path: Path, *, create: bool) -> tuple[Path, int]:
                     raise PrivatePathError("private_path_not_directory") from error
                 raise
             try:
-                _require_safe_ancestor_directory(next_descriptor)
+                current = current / component
+                _require_safe_ancestor_directory(next_descriptor, current, ancestors)
             except Exception:
                 os.close(next_descriptor)
                 raise
             os.close(descriptor)
             descriptor = next_descriptor
-        _require_private_owner_directory(descriptor)
-        return canonical, descriptor
+        return descriptor
     except Exception:
         os.close(descriptor)
         raise
@@ -106,29 +162,49 @@ def prepare_private_file(path: Path) -> Path:
 def tighten_private_file(path: Path) -> None:
     canonical = canonical_absolute_path(path)
     try:
-        descriptor = os.open(canonical, os.O_RDONLY | os.O_NOFOLLOW)
+        _, parent_descriptor = open_private_directory(canonical.parent, create=False)
     except FileNotFoundError:
         return
-    except OSError as error:
-        if error.errno in {errno.ELOOP, errno.ENOTDIR}:
-            raise PrivatePathError("private_file_not_regular") from error
-        raise
     try:
-        info = os.fstat(descriptor)
-        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.geteuid():
-            raise PrivatePathError("private_file_not_regular")
-        os.fchmod(descriptor, 0o600)
+        try:
+            descriptor = os.open(
+                canonical.name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=parent_descriptor,
+            )
+        except FileNotFoundError:
+            return
+        except OSError as error:
+            if error.errno in {errno.ELOOP, errno.ENOTDIR}:
+                raise PrivatePathError("private_file_not_regular") from error
+            raise
+        try:
+            info = os.fstat(descriptor)
+            if not stat.S_ISREG(info.st_mode) or info.st_uid != os.geteuid():
+                raise PrivatePathError("private_file_not_regular")
+            os.fchmod(descriptor, 0o600)
+        finally:
+            os.close(descriptor)
     finally:
-        os.close(descriptor)
+        os.close(parent_descriptor)
 
 
-def _require_safe_ancestor_directory(descriptor: int) -> None:
+def _require_safe_ancestor_directory(
+    descriptor: int,
+    path: Path | None = None,
+    ancestors: Mapping[Path, tuple[int, int, int]] | None = None,
+) -> None:
     info = os.fstat(descriptor)
     if not stat.S_ISDIR(info.st_mode):
         raise PrivatePathError("private_path_not_directory")
-    if info.st_uid not in {0, os.geteuid()}:
-        raise PrivatePathError("private_path_ancestor_owner_invalid")
+    pinned = ancestors.get(path) if ancestors is not None else None
     mode = stat.S_IMODE(info.st_mode)
+    if pinned is not None:
+        if (info.st_uid, info.st_dev, info.st_ino) != pinned:
+            raise PrivatePathError("trusted_ancestor_identity_mismatch")
+        # Sticky shared directories are not eligible for an ownership exception.
+        if mode & 0o022:
+            raise PrivatePathError("private_path_ancestor_permissions_invalid")
+    elif info.st_uid not in {0, os.geteuid()}:
+        raise PrivatePathError("private_path_ancestor_owner_invalid")
     if mode & 0o022 and not mode & stat.S_ISVTX:
         raise PrivatePathError("private_path_ancestor_permissions_invalid")
 

--- a/src/bridge/web/__init__.py
+++ b/src/bridge/web/__init__.py
@@ -1,0 +1,1 @@
+"""Authenticated, research-only conversational preview."""

--- a/src/bridge/web/__main__.py
+++ b/src/bridge/web/__main__.py
@@ -1,0 +1,30 @@
+"""Run one private loopback service; deployment configuration stays server-side."""
+import json
+import os
+from pathlib import Path
+
+import uvicorn
+
+from .app import Settings, create_app
+
+
+def main():
+    pins = json.loads(os.environ.get("BRIDGE_WEB_TRUSTED_ANCESTORS", "{}"))
+    if pins:
+        from bridge.storage.private_paths import configure_trusted_ancestors
+        configure_trusted_ancestors({Path(path): tuple(identity) for path, identity in pins.items()})
+    settings = Settings(
+        storage_root=Path(os.environ["BRIDGE_WEB_STORAGE"]),
+        token=os.environ["BRIDGE_WEB_TOKEN"],
+        model_base_url=os.environ["BRIDGE_WEB_MODEL_BASE_URL"],
+        model=os.environ["BRIDGE_WEB_MODEL"],
+        model_api_key=os.environ["BRIDGE_WEB_MODEL_API_KEY"],
+        origin=os.environ.get("BRIDGE_WEB_ORIGIN", "http://127.0.0.1:8765"),
+        static_dir=Path(os.environ["BRIDGE_WEB_STATIC_DIR"]) if os.environ.get("BRIDGE_WEB_STATIC_DIR") else None,
+    )
+    uvicorn.run(create_app(settings), host="127.0.0.1", port=int(os.environ.get("BRIDGE_WEB_PORT", "8765")),
+                access_log=False, proxy_headers=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bridge/web/app.py
+++ b/src/bridge/web/app.py
@@ -1,0 +1,607 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+from importlib.resources import files
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import stat
+from threading import BoundedSemaphore, RLock
+import time
+from urllib.parse import urlsplit
+
+from fastapi import FastAPI, File, HTTPException, Request, UploadFile
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse, Response
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, ConfigDict, Field
+
+from bridge.domain import AnalysisPlan, CaseInputAsset, CaseInputBundle, approve_plan
+from bridge.planner import PlanBuilder
+from bridge.runners import ToolExecutionPipeline, ToolExecutionScope
+from bridge.storage.private_paths import ensure_private_directory, verify_private_directory
+from bridge.workflow import LocalWorkflowExecutor, SQLiteRunEventStore
+from .provider import converse
+
+ID = re.compile(r"^[a-f0-9]{32}$")
+RETRACTION = re.compile(
+    r"不是|并非|不属于|不要|不能|不使用|没有|不做|停止|取消|撤回|撤销"
+    r"|\b(?:not|no|don.t|isn.t|aren.t|wasn.t|cancel|stop|retract|revoke)\b",
+    re.I,
+)
+COOKIE = "bridge_session"
+PUBLIC = ("id", "title", "updated_at", "status", "messages", "uploads", "plan", "artifacts", "error")
+
+
+@dataclass(frozen=True)
+class Settings:
+    storage_root: Path
+    token: str
+    model_base_url: str
+    model: str
+    model_api_key: str
+    origin: str = "http://127.0.0.1:8765"
+    static_dir: Path | None = None
+    upload_limit: int = 128 * 1024 * 1024
+    cookie_ttl: int = 12 * 3600
+
+    def __post_init__(self):
+        if len(self.token) < 24 or not self.model_api_key or not self.model:
+            raise ValueError("invalid_server_configuration")
+        for url in (self.origin, self.model_base_url):
+            parts = urlsplit(url)
+            if parts.scheme not in {"http", "https"} or not parts.hostname or parts.username or parts.password:
+                raise ValueError("invalid_server_configuration")
+
+
+class Body(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class Login(Body):
+    token: str = Field(max_length=1024)
+
+
+class Message(Body):
+    text: str = Field(min_length=1, max_length=8000)
+
+
+class Approval(Body):
+    plan_id: str = Field(max_length=100)
+    plan_digest: str = Field(pattern=r"^[a-f0-9]{64}$")
+
+
+def now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def uid():
+    return secrets.token_hex(16)
+
+
+def private_text(value: str) -> str:
+    # Paths are never useful in a remote model prompt or public-facing envelope.
+    return re.sub(r"(?<![\w:])(?:/[A-Za-z0-9_.-]+){2,}[^\s\"<>]*", "[private path omitted]", value)
+
+
+def read_file(path: Path, limit: int | None = None) -> bytes:
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    with os.fdopen(fd, "rb") as stream:
+        info = os.fstat(stream.fileno())
+        if not stat.S_ISREG(info.st_mode) or info.st_uid != os.geteuid():
+            raise ValueError("private_file_invalid")
+        if limit is not None and info.st_size > limit:
+            raise ValueError("private_file_too_large")
+        return stream.read()
+
+
+def write_file(path: Path, content: bytes):
+    ensure_private_directory(path.parent)
+    temporary = path.parent / (uid() + ".tmp")
+    fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if path.is_symlink():
+            raise ValueError("private_file_invalid")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def inspect_h5ad(path: Path) -> list[str]:
+    import h5py
+    with h5py.File(path, "r") as handle:
+        if handle.attrs.get("encoding-type") != "anndata" or "obs" not in handle or "var" not in handle:
+            raise ValueError("invalid_h5ad")
+        visited = set()
+        logical_bytes = 0
+        def check(group, depth=0):
+            nonlocal logical_bytes
+            if depth > 16 or len(visited) > 10000:
+                raise ValueError("h5ad_structure_limit")
+            for name in group:
+                link = group.get(name, getlink=True)
+                if not isinstance(link, h5py.HardLink):
+                    raise ValueError("h5ad_external_link")
+                item = group[name]
+                identity = hash(item.id)
+                if identity in visited:
+                    continue
+                visited.add(identity)
+                if isinstance(item, h5py.Group):
+                    check(item, depth + 1)
+                else:
+                    if item.is_virtual or item.external:
+                        raise ValueError("h5ad_external_dataset")
+                    logical_bytes += item.size * item.dtype.itemsize
+                    if item.size > 100_000_000 or logical_bytes > 512 * 1024 * 1024:
+                        raise ValueError("h5ad_dataset_limit")
+        check(handle)
+        return (["X"] if "X" in handle else []) + [
+            "layers/" + name for name in handle.get("layers", {})
+            if re.fullmatch(r"[A-Za-z0-9_.-]{1,80}", name)
+        ]
+
+
+class Service:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+        self.root, self.device, self.inode = ensure_private_directory(settings.storage_root)
+        self.lock = RLock()
+        self.cookies: dict[str, float] = {}
+        self.pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="bridge-web")
+        self.capacity = BoundedSemaphore(2)
+        self.executor = LocalWorkflowExecutor(SQLiteRunEventStore(self.root / "events.sqlite3"), max_attempts=1)
+        for item in self.root.iterdir():
+            if ID.fullmatch(item.name):
+                state = self.load(item.name)
+                if state["status"] in {"running", "thinking", "awaiting_approval"}:
+                    state["status"], state["error"] = "failed", "interrupted"
+                    if state["plan"]:
+                        state["plan"]["status"] = "failed"
+                    if state.get("_run_id"):
+                        self.executor.cancel(state["_run_id"])
+                    self.save(state)
+
+    def directory(self, sid):
+        verify_private_directory(self.root, device=self.device, inode=self.inode)
+        if not ID.fullmatch(sid):
+            raise HTTPException(404, "not_found")
+        target = self.root / sid
+        if not target.exists() or target.is_symlink():
+            raise HTTPException(404, "not_found")
+        ensure_private_directory(target)
+        return target
+
+    def load(self, sid):
+        return json.loads(read_file(self.directory(sid) / "session.json", 8 * 1024 * 1024))
+
+    def save(self, state):
+        state["updated_at"] = now()
+        write_file(self.directory(state["id"]) / "session.json",
+                   json.dumps(state, ensure_ascii=False).encode())
+
+    def public(self, state):
+        return {key: state[key] for key in PUBLIC}
+
+    def message(self, state, role, content):
+        state["messages"].append({"id": uid(), "role": role, "content": private_text(content), "created_at": now()})
+
+    def create(self):
+        sid = uid()
+        ensure_private_directory(self.root / sid)
+        state = {"id": sid, "title": "New analysis", "updated_at": now(), "status": "idle",
+                 "messages": [], "uploads": [], "plan": None, "artifacts": [], "error": None,
+                 "_uploads": {}, "_artifacts": {}, "_plan": None}
+        self.message(state, "assistant", "我是 BRIDGE。请描述研究问题并上传 H5AD。当前预览可执行输入 QC；其他分析需要额外科学输入。所有运行都需要您确认计划，不提供临床或放行结论。")
+        self.save(state)
+        return state
+
+    def busy(self, state):
+        if state["status"] in {"thinking", "running"}:
+            raise HTTPException(409, "session_busy")
+
+    def schedule(self, state, status, work):
+        if not self.capacity.acquire(blocking=False):
+            raise HTTPException(429, "worker_busy")
+        state["status"], state["error"] = status, None
+        self.save(state)
+        sid = state["id"]
+        def run():
+            try:
+                work(sid)
+            except Exception:
+                with self.lock:
+                    failed = self.load(sid)
+                    failed["status"] = "failed"
+                    failed["error"] = "provider_unavailable" if status == "thinking" else "execution_failed"
+                    if failed["plan"] and status == "running":
+                        failed["plan"]["status"] = "failed"
+                        for step in failed["plan"]["steps"]:
+                            if step["status"] in {"pending", "running"}:
+                                step["status"], step["reason"] = "failed", "execution_failed"
+                    self.save(failed)
+            finally:
+                self.capacity.release()
+        self.pool.submit(run)
+
+    def declaration(self, state, upload_id):
+        upload = state["_uploads"][upload_id]
+        user = next((item["content"] for item in reversed(state["messages"]) if item["role"] == "user"), "")
+        if re.search(r"[?？]", user) or RETRACTION.search(user):
+            return None
+        # Only explicit raw-count/QC intent may bind a matrix, never a model guess.
+        if re.search(r"(使用|原始计数|raw counts|/counts|\buse\b)", user, re.I):
+            if "layers/counts" in upload["locations"] and re.search(r"counts", user, re.I):
+                return "layers/counts"
+            if "X" in upload["locations"] and re.search(r"\bX\b", user):
+                return "X"
+        if (upload.get("suggested") == "layers/counts" and len(state["messages"]) >= 2
+                and state["messages"][-2]["id"] == upload.get("question_id")) and re.fullmatch(r"(是|是的|好|好的|确认|yes|ok)[。！! ]*", user, re.I):
+            return "layers/counts"
+        return None
+
+    def think(self, sid):
+        state = self.load(sid)
+        latest = state["messages"][-1]["content"]
+        if RETRACTION.search(latest):
+            state.pop("_pending_qc", None)
+            # A retraction fences off all earlier declarations conservatively.
+            # Both matrix intent and assay must be positively declared again.
+            for upload in state["_uploads"].values():
+                upload["declaration_start"] = len(state["messages"])
+                upload.pop("question_id", None)
+            self.save(state)
+        if state.get("_pending_qc") and self.assay(state, state["_pending_qc"]["upload_id"]):
+            self.prepare(state, **state["_pending_qc"])
+            return
+        if state["uploads"]:
+            selected = state["uploads"][-1]["id"]
+            location = self.declaration(state, selected)
+            if location:
+                self.prepare(state, selected, location)
+                return
+        context = {"status": "idle", "upload_ids": [item["id"] for item in state["uploads"]],
+                   "plan_status": state["plan"]["status"] if state["plan"] else None,
+                   "available_tool": "P0-01", "results_sent_to_model": False}
+        action = converse(self.settings, [{"role": item["role"], "content": private_text(item["content"])}
+                                         for item in state["messages"]], context)
+        if action.action == "prepare_qc":
+            if action.upload_id not in state["_uploads"]:
+                raise ValueError("unknown_upload")
+            declaration = self.declaration(state, action.upload_id)
+            if declaration != action.matrix_location:
+                self.message(state, "assistant", "请明确声明原始计数所在位置：例如“使用 counts 层进行 QC”，或“X 是原始计数，进行 QC”。不会根据文件名推断计数语义。")
+            else:
+                self.prepare(state, action.upload_id, declaration)
+                return
+        else:
+            self.message(state, "assistant", action.text)
+        state["status"] = "idle"
+        self.save(state)
+
+    def assay(self, state, upload_id):
+        start = state["_uploads"][upload_id]["declaration_start"]
+        for item in reversed(state["messages"][start:]):
+            if item["role"] == "user":
+                if RETRACTION.search(item["content"]):
+                    return None
+                if re.search(r"[?？]", item["content"]):
+                    continue
+                matches = re.findall(r"(?<![A-Za-z])(scRNA-seq|snRNA-seq)(?![A-Za-z])", item["content"])
+                if len(set(matches)) == 1:
+                    return matches[0]
+        return None
+
+    def prepare(self, state, upload_id, location):
+        assay = self.assay(state, upload_id)
+        if assay is None:
+            state["_pending_qc"] = {"upload_id": upload_id, "location": location}
+            state["status"] = "idle"
+            self.message(state, "assistant", "计数位置声明已记录。还需要您明确实验类型：scRNA-seq（单细胞）还是 snRNA-seq（单核）？不会根据表达数据自动推断。")
+            self.save(state)
+            return
+        state.pop("_pending_qc", None)
+        upload = state["_uploads"][upload_id]
+        if location not in upload["locations"]:
+            raise ValueError("matrix_not_registered")
+        directory, _, _ = ensure_private_directory(self.directory(state["id"]) / "uploads")
+        path = directory / (upload_id + ".h5ad")
+        data = read_file(path, self.settings.upload_limit)
+        if hashlib.sha256(data).hexdigest() != upload["sha256"]:
+            raise ValueError("upload_integrity_mismatch")
+        asset = CaseInputAsset(asset_id=upload_id, path=path, format="h5ad",
+                               input_level="count_ready", checksum=upload["sha256"],
+                               matrix_location=location, matrix_semantics="raw_counts", assay=assay)
+        bundle = CaseInputBundle(bundle_id=uid(), version="1", assets=[asset])
+        snapshot = files("bridge.resources").joinpath("knowledge_snapshot.json.gz").read_bytes()
+        plan = PlanBuilder().build(bundle, output_root=self.directory(state["id"]) / "runs",
+                                   knowledge_snapshot_ref="sha256:" + hashlib.sha256(snapshot).hexdigest())
+        state["_plan"] = plan.model_dump(mode="json")
+        state["plan"] = {"id": plan.plan_id, "digest": plan.approval_sha256(), "status": "proposed",
+                         "summary": "P0-01 输入 QC；实验类型：" + assay + "；原始计数位置：" + location + "。仅研究性候选结果；未声明 sample/capture 元数据，不推断生物学重复。",
+                         "steps": [{"id": item.step_id, "tool_id": item.tool_id, "label": "输入质量与可分析性",
+                                    "status": "pending" if item.disposition.value == "execute" else "skipped",
+                                    "reason": None if not item.reason_codes else "input_not_eligible"} for item in plan.steps]}
+        state["status"] = "awaiting_approval"
+        self.message(state, "assistant", "已根据您的计数声明生成输入 QC 计划。请检查并确认；确认前不会运行。结果不代表科学方法已验证。")
+        self.save(state)
+
+    def execute(self, sid):
+        state = self.load(sid)
+        plan = AnalysisPlan.model_validate(state["_plan"])
+        # Verify all registered input bytes immediately before any SDK execution.
+        for upload_id, upload in state["_uploads"].items():
+            directory, _, _ = ensure_private_directory(self.directory(sid) / "uploads")
+            path = directory / (upload_id + ".h5ad")
+            if hashlib.sha256(read_file(path, self.settings.upload_limit)).hexdigest() != upload["sha256"]:
+                raise ValueError("upload_integrity_mismatch")
+        run_id = self.executor.submit(plan)
+        state["_run_id"] = run_id
+        self.save(state)
+        pipeline = ToolExecutionPipeline(ToolExecutionScope.from_plan(plan))
+        while claim := self.executor.claim_step(run_id):
+            for item in state["plan"]["steps"]:
+                if item["id"] == claim.step_id:
+                    item["status"] = "running"
+            self.save(state)
+            outcome = self.executor.execute_claim(claim, pipeline)
+            self.register_artifacts(state, outcome)
+            for item in state["plan"]["steps"]:
+                if item["id"] == claim.step_id:
+                    item["status"] = "succeeded" if outcome.execution_state.value == "succeeded" else "failed"
+                    item["reason"] = None if item["status"] == "succeeded" else "tool_not_successful"
+            self.save(state)
+        snapshot = self.executor.get_status(run_id)
+        success = snapshot.status.value == "succeeded"
+        state["status"] = "idle" if success else "failed"
+        state["error"] = None if success else "execution_incomplete"
+        state["plan"]["status"] = "completed" if success else "failed"
+        self.message(state, "assistant", "输入 QC 运行已结束。请在结果面板查看工具生成的图表和证据。未声明的采样或捕获信息不会被补造；运行完成不代表科学验证通过，不能用于临床或放行结论。" if success else "QC 未完整完成。未将缺失或失败证据解释为产品失败。")
+        self.save(state)
+
+    def register_artifacts(self, state, outcome):
+        root = self.directory(state["id"])
+        for artifact in outcome.artifacts:
+            path = artifact.path
+            try:
+                relative = path.relative_to(root / "runs")
+            except ValueError:
+                raise ValueError("artifact_outside_run")
+            current = root / "runs"
+            for part in relative.parts:
+                current = current / part
+                if current.is_symlink():
+                    raise ValueError("artifact_symlink")
+            suffix = path.suffix.lower()
+            media = {".png": "image/png", ".svg": "image/svg+xml", ".json": "application/json",
+                     ".csv": "text/csv", ".tsv": "text/tab-separated-values",
+                     ".parquet": "application/octet-stream"}.get(suffix)
+            if not media:
+                continue
+            data = read_file(path, 128 * 1024 * 1024)
+            if hashlib.sha256(data).hexdigest() != artifact.sha256:
+                raise ValueError("artifact_integrity_mismatch")
+            if suffix == ".json":
+                def redact(value):
+                    if isinstance(value, dict):
+                        return {key: redact(item) for key, item in value.items() if "path" not in key.lower() and key not in {"output_dir"}}
+                    if isinstance(value, list):
+                        return [redact(item) for item in value]
+                    return private_text(value) if isinstance(value, str) else value
+                data = json.dumps(redact(json.loads(data)), ensure_ascii=False).encode()
+            aid = uid()
+            write_file(root / "artifacts" / (aid + suffix), data)
+            kind = "figure" if suffix in {".png", ".svg"} else "evidence" if suffix == ".json" else "table"
+            name = re.sub(r"[^A-Za-z0-9_.-]", "_", path.name)[:100]
+            if suffix == ".json":
+                name = name.removesuffix(".json") + ".display-redacted.json"
+            state["artifacts"].append({"id": aid, "name": name, "kind": kind, "media_type": media,
+                                       "url": f"/api/sessions/{state['id']}/artifacts/{aid}", "tool_id": outcome.request.tool_id})
+            state["_artifacts"][aid] = {"file": aid + suffix, "sha256": hashlib.sha256(data).hexdigest(),
+                                       "source_artifact_id": artifact.artifact_id, "source_sha256": artifact.sha256,
+                                       "projection": "path_redacted_display" if suffix == ".json" else "identity"}
+
+
+def create_app(settings: Settings) -> FastAPI:
+    service = Service(settings)
+
+    @asynccontextmanager
+    async def lifespan(app):
+        yield
+        service.pool.shutdown(wait=True, cancel_futures=False)
+
+    app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None, lifespan=lifespan)
+    app.state.service = service
+
+    @app.exception_handler(RequestValidationError)
+    async def invalid(request, exc):
+        return JSONResponse({"detail": "invalid_request"}, status_code=422)
+
+    @app.middleware("http")
+    async def boundary(request: Request, call_next):
+        if request.url.path.startswith("/api/"):
+            try:
+                received = 0
+                exceeded = False
+                if request.headers.get("host") != urlsplit(settings.origin).netloc:
+                    return JSONResponse({"detail": "invalid_host"}, status_code=403)
+                if request.method not in {"GET", "HEAD", "OPTIONS"}:
+                    if request.headers.get("origin") != settings.origin:
+                        return JSONResponse({"detail": "origin_required"}, status_code=403)
+                    length = request.headers.get("content-length")
+                    limit = settings.upload_limit + 65536 if request.url.path.endswith("/uploads") else 32768
+                    if length is None or not length.isdigit() or int(length) > limit:
+                        return JSONResponse({"detail": "request_too_large"}, status_code=413)
+                    original_receive = request._receive
+                    async def bounded_receive():
+                        nonlocal received, exceeded
+                        message = await original_receive()
+                        received += len(message.get("body", b""))
+                        if received > limit:
+                            exceeded = True
+                            raise ValueError("request_too_large")
+                        return message
+                    request._receive = bounded_receive
+                if request.url.path not in {"/api/health", "/api/login"}:
+                    token = request.cookies.get(COOKIE, "")
+                    if service.cookies.get(hashlib.sha256(token.encode()).hexdigest(), 0) <= time.time():
+                        return JSONResponse({"detail": "authentication_required"}, status_code=401)
+                response = await call_next(request)
+                if exceeded:
+                    response = JSONResponse({"detail": "request_too_large"}, status_code=413)
+            except Exception:
+                return JSONResponse({"detail": "request_failed"}, status_code=500)
+            response.headers["Cache-Control"] = "no-store"
+            response.headers["X-Content-Type-Options"] = "nosniff"
+            return response
+        return await call_next(request)
+
+    @app.get("/api/health")
+    def health():
+        return {"status": "ok"}
+
+    @app.post("/api/login")
+    def login(body: Login, response: Response):
+        if not secrets.compare_digest(body.token.encode(), settings.token.encode()):
+            raise HTTPException(401, "authentication_failed")
+        cookie = secrets.token_urlsafe(32)
+        with service.lock:
+            service.cookies = {key: expiry for key, expiry in service.cookies.items() if expiry > time.time()}
+            if len(service.cookies) >= 128:
+                raise HTTPException(429, "too_many_logins")
+            service.cookies[hashlib.sha256(cookie.encode()).hexdigest()] = time.time() + settings.cookie_ttl
+        response.set_cookie(COOKIE, cookie, httponly=True, samesite="strict", secure=settings.origin.startswith("https:"), max_age=settings.cookie_ttl)
+        return {"authenticated": True}
+
+    @app.post("/api/logout")
+    def logout(request: Request, response: Response):
+        with service.lock:
+            service.cookies.pop(hashlib.sha256(request.cookies.get(COOKIE, "").encode()).hexdigest(), None)
+        response.delete_cookie(COOKIE)
+        return {"authenticated": False}
+
+    @app.get("/api/sessions")
+    def sessions():
+        with service.lock:
+            states = [service.load(item.name) for item in service.root.iterdir() if ID.fullmatch(item.name)]
+            return {"sessions": sorted([{key: item[key] for key in ("id", "title", "updated_at")} for item in states],
+                                       key=lambda item: item["updated_at"], reverse=True)}
+
+    @app.post("/api/sessions")
+    def create():
+        with service.lock:
+            return service.public(service.create())
+
+    @app.get("/api/sessions/{sid}")
+    def get(sid: str):
+        with service.lock:
+            return service.public(service.load(sid))
+
+    @app.post("/api/sessions/{sid}/uploads")
+    def upload(sid: str, file: UploadFile = File(...)):
+        with service.lock:
+            state = service.load(sid)
+            service.busy(state)
+            if len(state["uploads"]) >= 8:
+                raise HTTPException(400, "upload_count_limit")
+            name = file.filename or ""
+            if "/" in name or "\\" in name or not name.lower().endswith(".h5ad") or len(name) > 120:
+                raise HTTPException(400, "invalid_upload_name")
+            content = file.file.read(settings.upload_limit + 1)
+            if len(content) > settings.upload_limit:
+                raise HTTPException(413, "upload_too_large")
+            if content[:8] != b"\x89HDF\r\n\x1a\n":
+                raise HTTPException(400, "invalid_h5ad")
+            aid = uid()
+            path = service.directory(sid) / "uploads" / (aid + ".h5ad")
+            write_file(path, content)
+            try:
+                locations = inspect_h5ad(path)
+            except Exception:
+                path.unlink(missing_ok=True)
+                raise HTTPException(400, "invalid_h5ad") from None
+            state["uploads"].append({"id": aid, "name": re.sub(r"[\x00-\x1f\x7f]", "", name), "kind": "h5ad", "size": len(content)})
+            state["_uploads"][aid] = {"sha256": hashlib.sha256(content).hexdigest(), "locations": locations, "declaration_start": len(state["messages"]),
+                                      "suggested": "layers/counts" if "layers/counts" in locations else None}
+            state.pop("_pending_qc", None)
+            state["plan"], state["_plan"], state["status"], state["error"] = None, None, "idle", None
+            service.message(state, "assistant", "文件已接收。检测到 counts 层：是否将它声明为原始计数并用于 QC？请回复“是，使用 counts 层进行 QC”。" if "layers/counts" in locations else "文件已接收。请声明原始计数位置，例如“X 是原始计数，进行 QC”。若 X 已标准化，请勿将它声明为原始计数。")
+            state["_uploads"][aid]["question_id"] = state["messages"][-1]["id"]
+            service.save(state)
+            return service.public(state)
+
+    @app.post("/api/sessions/{sid}/messages")
+    def message(sid: str, body: Message):
+        with service.lock:
+            state = service.load(sid)
+            service.busy(state)
+            if len(state["messages"]) >= 100:
+                raise HTTPException(400, "conversation_limit")
+            if not body.text.strip():
+                raise HTTPException(422, "invalid_request")
+            service.message(state, "user", body.text.strip())
+            if state["title"] == "New analysis":
+                state["title"] = private_text(body.text.strip())[:60]
+            # Any new user message invalidates an unapproved proposal.
+            if state["plan"] and state["plan"]["status"] == "proposed":
+                state["plan"], state["_plan"] = None, None
+            service.schedule(state, "thinking", service.think)
+            return service.public(state)
+
+    @app.post("/api/sessions/{sid}/approve")
+    def approve(sid: str, body: Approval):
+        with service.lock:
+            state = service.load(sid)
+            service.busy(state)
+            if state["status"] != "awaiting_approval" or not state["_plan"]:
+                raise HTTPException(409, "approval_not_pending")
+            plan = AnalysisPlan.model_validate(state["_plan"])
+            if body.plan_id != plan.plan_id or not secrets.compare_digest(body.plan_digest, plan.approval_sha256()):
+                raise HTTPException(409, "approval_mismatch")
+            approved = approve_plan(plan, approver_id="private-operator", authority_ref="web-session:" + sid,
+                                    approved_at=datetime.now(timezone.utc))
+            state["_plan"] = approved.model_dump(mode="json")
+            state["plan"]["status"] = "approved"
+            service.schedule(state, "running", service.execute)
+            return service.public(state)
+
+    @app.get("/api/sessions/{sid}/artifacts/{aid}")
+    def artifact(sid: str, aid: str):
+        with service.lock:
+            state = service.load(sid)
+            if not ID.fullmatch(aid) or aid not in state["_artifacts"]:
+                raise HTTPException(404, "not_found")
+            record = state["_artifacts"][aid]
+            path = service.directory(sid) / "artifacts" / record["file"]
+            if path.parent.is_symlink():
+                raise HTTPException(404, "not_found")
+            data = read_file(path, 128 * 1024 * 1024)
+            if hashlib.sha256(data).hexdigest() != record["sha256"]:
+                raise HTTPException(409, "artifact_integrity_mismatch")
+            public = next(item for item in state["artifacts"] if item["id"] == aid)
+            inline = public["media_type"] in {"image/png", "image/svg+xml"}
+            return Response(data, media_type=public["media_type"],
+                            headers={"Content-Disposition": ("inline" if inline else "attachment") + '; filename="' + public["name"] + '"',
+                                     "Content-Security-Policy": "default-src 'none'; sandbox", "X-Content-Type-Options": "nosniff"})
+
+    @app.get("/api/sessions/{sid}/transcript")
+    def transcript(sid: str):
+        state = service.load(sid)
+        text = "# BRIDGE research conversation\n\n" + "\n\n".join(
+            item["role"] + ":\n" + item["content"] for item in state["messages"])
+        return Response(text, media_type="text/markdown",
+                        headers={"Content-Disposition": 'attachment; filename="conversation.md"'})
+
+    if settings.static_dir is not None:
+        app.mount("/", StaticFiles(directory=settings.static_dir, html=True), name="web")
+    return app

--- a/src/bridge/web/provider.py
+++ b/src/bridge/web/provider.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from typing import Literal
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class Action(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    action: Literal["reply", "prepare_qc"]
+    text: str | None = Field(default=None, max_length=12000)
+    upload_id: str | None = Field(default=None, pattern=r"^[a-f0-9]{32}$")
+    matrix_location: str | None = Field(default=None, pattern=r"^(X|layers/[A-Za-z0-9_.-]{1,80})$")
+
+    @model_validator(mode="after")
+    def complete(self):
+        if self.action == "reply":
+            if not self.text or self.upload_id or self.matrix_location:
+                raise ValueError("invalid_reply")
+        elif not self.upload_id or not self.matrix_location or self.text:
+            raise ValueError("invalid_qc_action")
+        return self
+
+
+def parse_action(message: dict) -> Action:
+    calls = message.get("tool_calls")
+    if calls:
+        if len(calls) != 1:
+            raise ValueError("ambiguous_model_action")
+        function = calls[0]["function"]
+        arguments = json.loads(function["arguments"])
+        return Action.model_validate({**arguments, "action": function["name"]})
+    content = message.get("content")
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError("empty_model_response")
+    content = content.strip()
+    if content.startswith("```"):
+        content = content.removeprefix("```json").removeprefix("```").removesuffix("```").strip()
+    if content.startswith("{"):
+        return Action.model_validate(json.loads(content))
+    return Action(action="reply", text=content)
+
+
+SYSTEM = """You are BRIDGE, a research-only cell-therapy transcriptomic evidence assistant.
+Respond in the user's language. You can discuss the research question and prepare P0-01 input QC.
+Keep replies concise and ask only the next necessary question. Do not repeat the same disclaimer.
+The user uploads through the attachment control. Never ask them for upload IDs or server filenames:
+use registered IDs from the safe execution context. If none exist, ask them to upload an H5AD.
+Ask for assay and raw-count semantics in ordinary language; technical IDs are server-owned.
+Other analyses require additional reviewed scientific inputs; do not claim a full-chain analysis.
+Never invent measurements, sample/capture IDs, scientific conclusions or completed operations.
+No clinical efficacy, safety, GMP release, validated potency or ranking claims. Scores are not frozen.
+You receive conversation and minimal execution status only; you cannot inspect uploaded biological data.
+Never infer biological findings from execution success. Ask the user to inspect tool-owned results.
+Describe completed execution only at tool level. The context does not certify individual QC metrics,
+filtering or doublet detection: never say these operations ran. Describe possibilities conditionally.
+For QC ask the user to explicitly declare the raw-count matrix (X or layers/counts). No assumptions.
+Only prepare_qc after a user declaration; execution always requires separate exact plan approval.
+Use a normal text reply or the prepare_qc tool. If tool calls are unavailable return one JSON object
+{"action":"reply","text":"..."} or {"action":"prepare_qc","upload_id":"...","matrix_location":"X"}.
+Never ask for credentials or private server paths. Do not echo paths from user messages.
+"""
+
+
+def converse(settings, messages: list[dict], context: dict) -> Action:
+    payload = {
+        "model": settings.model,
+        # Keep one leading system message and the latest user turn last. Some
+        # compatible providers stop without output after a trailing system turn.
+        "messages": [{"role": "system", "content": SYSTEM + "\nSafe execution context: " + json.dumps(context)},
+                     *messages[-24:]],
+        "tools": [{"type": "function", "function": {
+            "name": "prepare_qc", "description": "Propose QC for a registered upload and explicitly declared raw-count matrix.",
+            "parameters": {"type": "object", "additionalProperties": False,
+                           "properties": {"upload_id": {"type": "string"}, "matrix_location": {"type": "string"}},
+                           "required": ["upload_id", "matrix_location"]}}}],
+        "max_tokens": 1800,
+    }
+    with httpx.Client(timeout=90, follow_redirects=False) as client:
+        response = client.post(settings.model_base_url.rstrip("/") + "/chat/completions",
+                               headers={"Authorization": "Bearer " + settings.model_api_key}, json=payload)
+        response.raise_for_status()
+        if len(response.content) > 256_000:
+            raise ValueError("provider_response_too_large")
+        return parse_action(response.json()["choices"][0]["message"])

--- a/tests/test_private_path_trust.py
+++ b/tests/test_private_path_trust.py
@@ -1,0 +1,247 @@
+"""Private-path trust tests use synthetic directories and simulated foreign ownership."""
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from bridge.storage import private_paths as paths
+
+
+@pytest.fixture(autouse=True)
+def isolated_startup_policy(monkeypatch):
+    # Production has no reset API: each test represents a fresh process.
+    monkeypatch.setattr(paths, "_trusted_ancestors", {}, raising=False)
+    monkeypatch.setattr(paths, "_trust_frozen", False, raising=False)
+
+
+@pytest.fixture
+def tree(tmp_path, monkeypatch):
+    shared = tmp_path / "shared"
+    shared.mkdir(mode=0o755)
+    leaf = shared / "private"
+    leaf.mkdir(mode=0o700)
+    (leaf / "record").write_bytes(b"synthetic")
+    original_fstat = os.fstat
+    foreign = {}
+
+    def pretend_foreign(path):
+        info = path.stat()
+        foreign[(info.st_dev, info.st_ino)] = os.geteuid() + 12345
+        return (os.geteuid() + 12345, info.st_dev, info.st_ino)
+
+    def observed_fstat(fd):
+        info = original_fstat(fd)
+        uid = foreign.get((info.st_dev, info.st_ino))
+        if uid is None:
+            return info
+        fields = list(info)
+        fields[4] = uid
+        return os.stat_result(fields)
+
+    monkeypatch.setattr(paths.os, "fstat", observed_fstat)
+    return shared, leaf, pretend_foreign(shared), pretend_foreign
+
+
+OPERATIONS = ("open", "ensure", "verify", "prepare", "tighten")
+
+
+def invoke(operation, leaf):
+    if operation == "open":
+        canonical, fd = paths.open_private_directory(leaf, create=False)
+        os.close(fd)
+        assert canonical == leaf
+    elif operation == "ensure":
+        canonical, device, inode = paths.ensure_private_directory(leaf)
+        assert canonical == leaf
+        assert (device, inode) == (leaf.stat().st_dev, leaf.stat().st_ino)
+    elif operation == "verify":
+        info = leaf.stat()
+        paths.verify_private_directory(leaf, device=info.st_dev, inode=info.st_ino)
+    elif operation == "prepare":
+        assert paths.prepare_private_file(leaf / "record") == leaf / "record"
+    else:
+        paths.tighten_private_file(leaf / "record")
+    assert (leaf / "record").read_bytes() == b"synthetic"
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_unconfigured_foreign_ancestor_is_rejected(tree, operation):
+    _, leaf, _, _ = tree
+    with pytest.raises(paths.PrivatePathError, match="ancestor_owner_invalid"):
+        invoke(operation, leaf)
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_exact_pinned_ancestor_allows_private_leaf(tree, operation):
+    shared, leaf, pin, _ = tree
+    paths.configure_trusted_ancestors({shared: pin})
+    invoke(operation, leaf)
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_other_foreign_ancestor_is_not_implicitly_trusted(tree, operation):
+    shared, leaf, pin, pretend_foreign = tree
+    nested = leaf / "other"
+    nested.mkdir(mode=0o755)
+    private = nested / "private"
+    private.mkdir(mode=0o700)
+    (private / "record").write_bytes(b"synthetic")
+    pretend_foreign(nested)
+    paths.configure_trusted_ancestors({shared: pin})
+    with pytest.raises(paths.PrivatePathError, match="ancestor_owner_invalid"):
+        invoke(operation, private)
+
+
+@pytest.mark.parametrize("field", (0, 1, 2), ids=("uid", "device", "inode"))
+def test_startup_rejects_mismatched_pin(tree, field):
+    shared, _, pin, _ = tree
+    incorrect = list(pin)
+    incorrect[field] += 1
+    with pytest.raises(paths.PrivatePathError, match="trusted_ancestor_identity_mismatch"):
+        paths.configure_trusted_ancestors({shared: tuple(incorrect)})
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+@pytest.mark.parametrize("change", ("replacement", "symlink", "writable", "nonprivate_leaf", "foreign_leaf"))
+def test_trust_preserves_security_checks_after_startup(tree, operation, change):
+    shared, leaf, pin, pretend_foreign = tree
+    paths.configure_trusted_ancestors({shared: pin})
+    if change in {"replacement", "symlink"}:
+        moved = shared.with_name("original")
+        shared.rename(moved)
+        if change == "symlink":
+            shared.symlink_to(moved, target_is_directory=True)
+        else:
+            shared.mkdir(mode=0o755)
+            leaf.mkdir(mode=0o700)
+            (leaf / "record").write_bytes(b"synthetic")
+    elif change == "writable":
+        shared.chmod(0o777)
+    elif change == "nonprivate_leaf":
+        leaf.chmod(0o755)
+    else:
+        pretend_foreign(leaf)
+    with pytest.raises(paths.PrivatePathError):
+        invoke(operation, leaf)
+
+
+@pytest.mark.parametrize("mode", (0o777, 0o1777))
+def test_startup_rejects_writable_trusted_ancestor_even_if_sticky(tree, mode):
+    shared, _, pin, _ = tree
+    shared.chmod(mode)
+    with pytest.raises(paths.PrivatePathError, match="ancestor_permissions_invalid"):
+        paths.configure_trusted_ancestors({shared: pin})
+
+
+def test_startup_rejects_symlink_alias(tree):
+    shared, _, pin, _ = tree
+    alias = shared.with_name("alias")
+    alias.symlink_to(shared, target_is_directory=True)
+    with pytest.raises(paths.PrivatePathError, match="not_directory"):
+        paths.configure_trusted_ancestors({alias: pin})
+
+
+def test_trusted_path_cannot_be_used_as_foreign_owned_private_leaf(tree):
+    shared, _, pin, _ = tree
+    paths.configure_trusted_ancestors({shared: pin})
+    with pytest.raises(paths.PrivatePathError):
+        paths.ensure_private_directory(shared)
+
+
+def test_startup_configuration_is_copied_and_cannot_be_expanded(tree):
+    shared, leaf, pin, _ = tree
+    policy = {shared: pin}
+    paths.configure_trusted_ancestors(policy)
+    policy.clear()
+    invoke("open", leaf)
+    paths.configure_trusted_ancestors({shared: pin})
+    with pytest.raises(paths.PrivatePathError, match="trust_configuration_locked"):
+        paths.configure_trusted_ancestors({})
+
+
+def test_first_use_locks_strict_default_even_after_rejected_access(tree):
+    shared, leaf, pin, _ = tree
+    with pytest.raises(paths.PrivatePathError):
+        paths.ensure_private_directory(leaf)
+    with pytest.raises(paths.PrivatePathError, match="trust_configuration_locked"):
+        paths.configure_trusted_ancestors({shared: pin})
+
+
+@pytest.mark.parametrize("operation", ("prepare", "tighten"))
+def test_file_symlinks_are_rejected_without_changing_target(tree, operation):
+    shared, leaf, pin, _ = tree
+    target = leaf / "target"
+    target.write_bytes(b"private")
+    target.chmod(0o644)
+    (leaf / "record").unlink()
+    (leaf / "record").symlink_to(target)
+    paths.configure_trusted_ancestors({shared: pin})
+    with pytest.raises(paths.PrivatePathError, match="private_file_not_regular"):
+        invoke(operation, leaf)
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+
+def test_missing_file_tighten_remains_noop(tmp_path):
+    paths.tighten_private_file(tmp_path / "absent")
+    paths.tighten_private_file(tmp_path / "absent-parent" / "absent")
+
+
+def test_created_directories_and_files_remain_private(tree):
+    shared, _, pin, _ = tree
+    paths.configure_trusted_ancestors({shared: pin})
+    leaf, _, _ = paths.ensure_private_directory(shared / "new" / "private")
+    file = paths.prepare_private_file(leaf / "record")
+    assert stat.S_IMODE(leaf.stat().st_mode) == 0o700
+    assert stat.S_IMODE(file.stat().st_mode) == 0o600
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+@pytest.mark.parametrize("field", (0, 1, 2), ids=("uid", "device", "inode"))
+def test_pins_are_rechecked_on_every_access(tree, monkeypatch, operation, field):
+    shared, leaf, pin, _ = tree
+    paths.configure_trusted_ancestors({shared: pin})
+    original_fstat = os.fstat
+
+    def changed_identity(fd):
+        info = original_fstat(fd)
+        if (info.st_dev, info.st_ino) != pin[1:]:
+            return info
+        fields = list(info)
+        fields[(4, 2, 1)[field]] += 1
+        return os.stat_result(fields)
+
+    monkeypatch.setattr(paths.os, "fstat", changed_identity)
+    with pytest.raises(paths.PrivatePathError, match="trusted_ancestor_identity_mismatch"):
+        invoke(operation, leaf)
+
+
+@pytest.mark.parametrize("identity", ((-1, 1, 1), (True, 1, 1), (1, 1), [1, 1, 1]))
+def test_malformed_identity_does_not_install_partial_policy(tree, identity):
+    shared, leaf, pin, _ = tree
+    with pytest.raises(paths.PrivatePathError, match="configuration_invalid"):
+        paths.configure_trusted_ancestors({shared: identity})
+    with pytest.raises(paths.PrivatePathError, match="ancestor_owner_invalid"):
+        invoke("open", leaf)
+
+
+def test_failed_validation_does_not_install_earlier_valid_entries(tree):
+    shared, leaf, pin, _ = tree
+    with pytest.raises(FileNotFoundError):
+        paths.configure_trusted_ancestors({shared: pin, shared / "absent": (1, 1, 1)})
+    with pytest.raises(paths.PrivatePathError, match="ancestor_owner_invalid"):
+        invoke("open", leaf)
+
+
+@pytest.mark.parametrize("path", (Path("relative"), Path("/"), Path("/safe/../other")))
+def test_nonexact_trust_paths_are_rejected(path):
+    with pytest.raises(paths.PrivatePathError):
+        paths.configure_trusted_ancestors({path: (1, 1, 1)})
+
+
+def test_final_directory_identity_is_still_verified(tree):
+    shared, leaf, pin, _ = tree
+    paths.configure_trusted_ancestors({shared: pin})
+    info = leaf.stat()
+    with pytest.raises(paths.PrivatePathError, match="private_directory_identity_mismatch"):
+        paths.verify_private_directory(leaf, device=info.st_dev, inode=info.st_ino + 1)

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+httpx = pytest.importorskip("httpx")
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from bridge.web.app import Settings, create_app
+from bridge.web.provider import parse_action
+
+
+def test_provider_accepts_real_tool_call_and_content_fallback():
+    action = {"action": "prepare_qc", "upload_id": "a" * 32, "matrix_location": "X"}
+    assert parse_action({"content": json.dumps(action)}).action == "prepare_qc"
+    assert parse_action({"tool_calls": [{"function": {"name": "prepare_qc", "arguments": json.dumps({k: v for k, v in action.items() if k != "action"})}}]}).matrix_location == "X"
+    assert parse_action({"content": "Please upload a file."}).text == "Please upload a file."
+    with pytest.raises(ValueError):
+        parse_action({"content": '{"action":"shell","command":"ls"}'})
+    with pytest.raises(ValueError):
+        parse_action({"content": '{"action":"prepare_qc","upload_id":"abc","matrix_location":"../../secret"}'})
+
+
+@pytest.fixture
+def client(tmp_path):
+    config = Settings(storage_root=tmp_path / "private", token="t" * 32,
+                      model_base_url="https://provider.invalid/v1", model="test-model",
+                      model_api_key="private-key", origin="http://testserver")
+    app = create_app(config)
+    with TestClient(app) as client:
+        client.headers["Origin"] = "http://testserver"
+        yield client
+
+
+def login(client):
+    assert client.post("/api/login", json={"token": "t" * 32}).status_code == 200
+
+
+def new_session(client):
+    login(client)
+    return client.post("/api/sessions").json()
+
+
+def settle(client, sid, timeout=90):
+    until = time.monotonic() + timeout
+    while time.monotonic() < until:
+        value = client.get(f"/api/sessions/{sid}").json()
+        if value["status"] not in {"thinking", "running"}:
+            return value
+        time.sleep(.05)
+    pytest.fail("worker did not finish")
+
+
+def h5ad(tmp_path, *, layer=False):
+    import anndata as ad
+    import numpy as np
+    import pandas as pd
+    from scipy import sparse
+    data = ad.AnnData(sparse.csr_matrix(np.array([[1, 2, 0], [2, 0, 1], [0, 3, 1], [2, 1, 1]], dtype=np.int64)),
+                      obs=pd.DataFrame(index=["private-cell-a", "b", "c", "d"]),
+                      var=pd.DataFrame(index=["MT-ND1", "SOX2", "FOXA2"]))
+    if layer:
+        data.layers["counts"] = data.X.copy()
+    path = tmp_path / "synthetic.h5ad"
+    data.write_h5ad(path)
+    return path.read_bytes()
+
+
+def test_auth_origin_logout_and_path_boundaries(client):
+    assert client.get("/api/health").json() == {"status": "ok"}
+    assert client.get("/api/sessions").status_code == 401
+    assert client.post("/api/login", json={"token": "wrong"}).status_code == 401
+    assert client.post("/api/login", json={"token": "t" * 32}, headers={"Origin": "https://evil.invalid"}).status_code == 403
+    login(client)
+    cookie = client.cookies.get("bridge_session")
+    assert cookie and cookie != "t" * 32
+    assert client.get("/api/sessions/" + "a" * 32).status_code == 404
+    assert client.get("/api/sessions/%2e%2e%2fsecret").status_code == 404
+    assert client.post("/api/logout").status_code == 200
+    assert client.get("/api/sessions").status_code == 401
+
+
+def test_upload_validation_and_private_state(client, tmp_path):
+    session = new_session(client)
+    url = f"/api/sessions/{session['id']}/uploads"
+    assert client.post(url, files={"file": ("../bad.h5ad", b"not hdf5")}).status_code == 400
+    response = client.post(url, files={"file": ("private.h5ad", h5ad(tmp_path, layer=True))})
+    assert response.status_code == 200
+    value = response.json()
+    assert value["uploads"][0]["kind"] == "h5ad"
+    assert str(tmp_path) not in response.text
+    assert "private-cell-a" not in response.text
+    assert value["plan"] is None
+    assert "counts" in value["messages"][-1]["content"]
+    assert client.get(f"/api/sessions/{session['id']}/artifacts/" + "a" * 32).status_code == 404
+
+
+def test_model_context_and_real_http_error(client, monkeypatch):
+    sid = new_session(client)["id"]
+    def response(request):
+        payload = json.loads(request.content)
+        assert "tool_choice" not in payload
+        assert [item["role"] for item in payload["messages"]].count("system") == 1
+        assert payload["messages"][0]["role"] == "system"
+        assert "Safe execution context:" in payload["messages"][0]["content"]
+        assert payload["messages"][-1] == {"role": "user", "content": "What can you do?"}
+        assert "private-key" not in json.dumps(payload)
+        return httpx.Response(200, json={"choices": [{"message": {"content": "I can help prepare QC."}}]})
+    original = httpx.Client
+    monkeypatch.setattr("bridge.web.provider.httpx.Client", lambda **kwargs: original(transport=httpx.MockTransport(response), **kwargs))
+    client.post(f"/api/sessions/{sid}/messages", json={"text": "What can you do?"})
+    value = settle(client, sid)
+    assert value["messages"][-1]["content"] == "I can help prepare QC."
+    monkeypatch.setattr("bridge.web.provider.httpx.Client", lambda **kwargs: original(transport=httpx.MockTransport(lambda request: httpx.Response(502, text="/private/provider/key")), **kwargs))
+    client.post(f"/api/sessions/{sid}/messages", json={"text": "Continue"})
+    failed = settle(client, sid)
+    assert failed["status"] == "failed"
+    assert failed["error"] == "provider_unavailable"
+    assert "/private/provider/key" not in json.dumps(failed)
+
+
+def test_real_qc_exact_approval_and_artifacts(client, tmp_path):
+    sid = new_session(client)["id"]
+    client.post(f"/api/sessions/{sid}/uploads", files={"file": ("synthetic.h5ad", h5ad(tmp_path, layer=True))})
+    client.post(f"/api/sessions/{sid}/messages", json={"text": "是，使用 counts 层进行 QC"})
+    value = settle(client, sid)
+    assert value["status"] == "idle", value
+    assert value["plan"] is None
+    assert "scRNA-seq" in value["messages"][-1]["content"]
+    client.post(f"/api/sessions/{sid}/messages", json={"text": "这是 scRNA-seq 数据"})
+    value = settle(client, sid)
+    assert value["status"] == "awaiting_approval", value
+    plan = value["plan"]
+    assert client.post(f"/api/sessions/{sid}/approve", json={"plan_id": plan["id"], "plan_digest": "0" * 64}).status_code == 409
+    assert client.post(f"/api/sessions/{sid}/approve", json={"plan_id": plan["id"], "plan_digest": plan["digest"]}).status_code == 200
+    done = settle(client, sid)
+    assert done["status"] == "idle", done
+    assert done["plan"]["status"] == "completed"
+    assert done["artifacts"]
+    assert any(item["kind"] == "figure" for item in done["artifacts"])
+    evidence = [item for item in done["artifacts"] if item["kind"] == "evidence"]
+    assert evidence and all(item["name"].endswith(".display-redacted.json") for item in evidence)
+    assert all("source_sha256" in client.app.state.service.load(sid)["_artifacts"][item["id"]] for item in evidence)
+    assert str(tmp_path) not in json.dumps(done)
+    for artifact in done["artifacts"]:
+        response = client.get(artifact["url"])
+        assert response.status_code == 200
+        assert response.headers["x-content-type-options"] == "nosniff"
+    assert client.post(f"/api/sessions/{sid}/approve", json={"plan_id": plan["id"], "plan_digest": plan["digest"]}).status_code == 409
+
+
+def test_restart_interrupts_never_reexecutes(client):
+    sid = new_session(client)["id"]
+    store = client.app.state.service
+    state = store.load(sid)
+    state["status"] = "running"
+    store.save(state)
+    other = create_app(store.settings)
+    with TestClient(other) as restarted:
+        restarted.headers["Origin"] = "http://testserver"
+        login(restarted)
+        value = restarted.get(f"/api/sessions/{sid}").json()
+        assert value["status"] == "failed"
+        assert value["error"] == "interrupted"
+
+def test_unknown_artifacts_are_session_scoped(client, tmp_path):
+    first = new_session(client)["id"]
+    second = client.post("/api/sessions").json()["id"]
+    assert client.get(f"/api/sessions/{second}/artifacts/{first}").status_code == 404
+    assert client.get(f"/api/sessions/{first}/artifacts/%2e%2e%2fprivate").status_code == 404
+
+
+def test_expired_cookie_and_oversized_body_are_rejected(client):
+    new_session(client)
+    for key in client.app.state.service.cookies:
+        client.app.state.service.cookies[key] = 0
+    assert client.get("/api/sessions").status_code == 401
+    login(client)
+    assert client.post("/api/sessions", content=b"x" * 40000).status_code == 413
+
+
+def test_assay_must_be_declared_for_each_upload(client, tmp_path):
+    sid = new_session(client)["id"]
+    url = f"/api/sessions/{sid}"
+    data = h5ad(tmp_path, layer=True)
+    client.post(url + "/uploads", files={"file": ("first.h5ad", data)})
+    client.post(url + "/messages", json={"text": "scRNA-seq，使用 counts 层进行 QC"})
+    assert settle(client, sid)["status"] == "awaiting_approval"
+    client.post(url + "/uploads", files={"file": ("second.h5ad", data)})
+    client.post(url + "/messages", json={"text": "使用 counts 层进行 QC"})
+    result = settle(client, sid)
+    assert result["status"] == "idle"
+    assert result["plan"] is None
+
+
+def test_changed_upload_never_executes_and_error_is_safe(client, tmp_path):
+    sid = new_session(client)["id"]
+    url = f"/api/sessions/{sid}"
+    client.post(url + "/uploads", files={"file": ("synthetic.h5ad", h5ad(tmp_path, layer=True))})
+    client.post(url + "/messages", json={"text": "scRNA-seq，使用 counts 层进行 QC"})
+    proposal = settle(client, sid)["plan"]
+    store = client.app.state.service
+    aid = store.load(sid)["uploads"][0]["id"]
+    path = store.root / sid / "uploads" / (aid + ".h5ad")
+    path.write_bytes(b"changed")
+    client.post(url + "/approve", json={"plan_id": proposal["id"], "plan_digest": proposal["digest"]})
+    result = settle(client, sid)
+    assert result["status"] == "failed"
+    assert result["error"] == "execution_failed"
+    assert result["artifacts"] == []
+    assert str(tmp_path) not in json.dumps(result)
+
+
+def test_symlink_upload_directory_never_plans(client, tmp_path):
+    sid = new_session(client)["id"]
+    url = f"/api/sessions/{sid}"
+    client.post(url + "/uploads", files={"file": ("synthetic.h5ad", h5ad(tmp_path, layer=True))})
+    directory = client.app.state.service.root / sid / "uploads"
+    destination = tmp_path / "moved-upload"
+    directory.rename(destination)
+    directory.symlink_to(destination, target_is_directory=True)
+    client.post(url + "/messages", json={"text": "scRNA-seq，使用 counts 层进行 QC"})
+    result = settle(client, sid)
+    assert result["status"] == "failed"
+    assert result["plan"] is None
+
+
+def test_hdf5_external_links_rejected(client, tmp_path):
+    import h5py
+    sid = new_session(client)["id"]
+    path = tmp_path / "external.h5ad"
+    path.write_bytes(h5ad(tmp_path))
+    with h5py.File(path, "a") as handle:
+        handle["external"] = h5py.ExternalLink("/private/data.h5ad", "/")
+    response = client.post(f"/api/sessions/{sid}/uploads", files={"file": ("external.h5ad", path.read_bytes())})
+    assert response.status_code == 400
+    assert "/private/" not in response.text
+
+
+def test_provider_cannot_prepare_without_explicit_declaration(client, monkeypatch, tmp_path):
+    sid = new_session(client)["id"]
+    url = f"/api/sessions/{sid}"
+    response = client.post(url + "/uploads", files={"file": ("synthetic.h5ad", h5ad(tmp_path, layer=True))})
+    aid = response.json()["uploads"][0]["id"]
+    original = httpx.Client
+    def provider(request):
+        payload = json.loads(request.content)
+        encoded = json.dumps(payload)
+        assert "private-cell-a" not in encoded
+        assert str(tmp_path) not in encoded
+        assert "synthetic.h5ad" not in encoded
+        return httpx.Response(200, json={"choices": [{"message": {"content": json.dumps({"action": "prepare_qc", "upload_id": aid, "matrix_location": "layers/counts"})}}]})
+    monkeypatch.setattr("bridge.web.provider.httpx.Client", lambda **kwargs: original(transport=httpx.MockTransport(provider), **kwargs))
+    client.post(url + "/messages", json={"text": "Can you explain this workflow?"})
+    value = settle(client, sid)
+    assert value["status"] == "idle"
+    assert value["plan"] is None
+
+def test_hdf5_external_dataset_rejected(client, tmp_path):
+    import h5py
+    sid = new_session(client)["id"]
+    path = tmp_path / "external-array.h5ad"
+    path.write_bytes(h5ad(tmp_path))
+    with h5py.File(path, "a") as handle:
+        handle.create_dataset("external_array", (10,), dtype="i4", external=[("not-loaded.bin", 0, 40)])
+    response = client.post(f"/api/sessions/{sid}/uploads", files={"file": ("external-array.h5ad", path.read_bytes())})
+    assert response.status_code == 400
+
+@pytest.mark.parametrize("text", ["counts 层不是原始计数", "scRNA-seq，使用 counts 层？", "不要使用 counts 层进行 QC"])
+def test_ambiguous_or_negative_counts_never_prepare(client, tmp_path, monkeypatch, text):
+    sid = new_session(client)["id"]
+    url = f"/api/sessions/{sid}"
+    client.post(url + "/uploads", files={"file": ("synthetic.h5ad", h5ad(tmp_path, layer=True))})
+    original = httpx.Client
+    monkeypatch.setattr("bridge.web.provider.httpx.Client", lambda **kwargs: original(transport=httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"choices": [{"message": {"content": "请明确计数语义。"}}]})), **kwargs))
+    client.post(url + "/messages", json={"text": text})
+    value = settle(client, sid)
+    assert value["plan"] is None
+    assert "_pending_qc" not in client.app.state.service.load(sid)
+
+def test_underreported_content_length_still_bounds_received_json(client):
+    sid = new_session(client)["id"]
+    response = client.post(f"/api/sessions/{sid}/messages",
+                           content=json.dumps({"text": "x" * 40000}),
+                           headers={"Content-Length": "1", "Content-Type": "application/json"})
+    assert response.status_code == 413
+
+def test_cancelled_pending_counts_does_not_prepare_on_assay_mention(client, tmp_path, monkeypatch):
+    sid = new_session(client)["id"]
+    url = f"/api/sessions/{sid}"
+    client.post(url + "/uploads", files={"file": ("synthetic.h5ad", h5ad(tmp_path, layer=True))})
+    client.post(url + "/messages", json={"text": "使用 counts 层进行 QC"})
+    assert settle(client, sid)["plan"] is None
+    original = httpx.Client
+    monkeypatch.setattr("bridge.web.provider.httpx.Client", lambda **kwargs: original(transport=httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"choices": [{"message": {"content": "已取消准备计划。"}}]})), **kwargs))
+    client.post(url + "/messages", json={"text": "不要 QC，这是 scRNA-seq"})
+    assert settle(client, sid)["plan"] is None
+
+@pytest.mark.parametrize("text", [
+    "This is not scRNA-seq; X contains raw counts",
+    "Do not use X as raw counts; this is scRNA-seq",
+    "This isn't scRNA-seq; X contains raw counts",
+])
+def test_english_negative_matrix_and_assay_never_prepare(client, tmp_path, monkeypatch, text):
+    sid = new_session(client)["id"]
+    url = f"/api/sessions/{sid}"
+    client.post(url + "/uploads", files={"file": ("synthetic.h5ad", h5ad(tmp_path))})
+    original = httpx.Client
+    monkeypatch.setattr("bridge.web.provider.httpx.Client", lambda **kwargs: original(transport=httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"choices": [{"message": {"content": "Please clarify your declaration."}}]})), **kwargs))
+    client.post(url + "/messages", json={"text": text})
+    value = settle(client, sid)
+    assert value["plan"] is None
+    assert "_pending_qc" not in client.app.state.service.load(sid)
+
+
+@pytest.mark.parametrize("retraction", ["counts 层不是原始计数", "The counts layer is not raw counts"])
+def test_retracted_pending_matrix_requires_fresh_positive_declaration(client, tmp_path, monkeypatch, retraction):
+    sid = new_session(client)["id"]
+    url = f"/api/sessions/{sid}"
+    client.post(url + "/uploads", files={"file": ("synthetic.h5ad", h5ad(tmp_path, layer=True))})
+    original = httpx.Client
+    monkeypatch.setattr("bridge.web.provider.httpx.Client", lambda **kwargs: original(transport=httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"choices": [{"message": {"content": "Please provide a fresh declaration."}}]})), **kwargs))
+    def say(text):
+        client.post(url + "/messages", json={"text": text})
+        return settle(client, sid)
+    assert say("使用 counts 层进行 QC")["plan"] is None
+    assert say(retraction)["plan"] is None
+    assert say("实验类型是 scRNA-seq")["plan"] is None
+    assert "_pending_qc" not in client.app.state.service.load(sid)
+    restored = say("使用 counts 层进行 QC")
+    assert restored["status"] == "awaiting_approval"
+    assert "scRNA-seq" in restored["plan"]["summary"]
+    assert "layers/counts" in restored["plan"]["summary"]
+
+
+@pytest.mark.parametrize("retraction", ["不是 scRNA-seq", "This is not scRNA-seq"])
+def test_retracted_assay_does_not_reuse_older_positive_assay(client, tmp_path, monkeypatch, retraction):
+    sid = new_session(client)["id"]
+    url = f"/api/sessions/{sid}"
+    client.post(url + "/uploads", files={"file": ("synthetic.h5ad", h5ad(tmp_path, layer=True))})
+    original = httpx.Client
+    monkeypatch.setattr("bridge.web.provider.httpx.Client", lambda **kwargs: original(transport=httpx.MockTransport(
+        lambda request: httpx.Response(200, json={"choices": [{"message": {"content": "Please provide a fresh declaration."}}]})), **kwargs))
+    def say(text):
+        client.post(url + "/messages", json={"text": text})
+        return settle(client, sid)
+    assert say("scRNA-seq，使用 counts 层进行 QC")["status"] == "awaiting_approval"
+    assert say(retraction)["plan"] is None
+    waiting = say("使用 counts 层进行 QC")
+    assert waiting["plan"] is None
+    restored = say("实验类型是 snRNA-seq")
+    assert restored["status"] == "awaiting_approval"
+    assert "snRNA-seq" in restored["plan"]["summary"]
+    assert "scRNA-seq" not in restored["plan"]["summary"]
+
+def test_retraction_persists_even_when_provider_fails(client, tmp_path, monkeypatch):
+    sid = new_session(client)["id"]
+    url = f"/api/sessions/{sid}"
+    client.post(url + "/uploads", files={"file": ("synthetic.h5ad", h5ad(tmp_path, layer=True))})
+    client.post(url + "/messages", json={"text": "使用 counts 层进行 QC"})
+    settle(client, sid)
+    original = httpx.Client
+    monkeypatch.setattr("bridge.web.provider.httpx.Client", lambda **kwargs: original(transport=httpx.MockTransport(
+        lambda request: httpx.Response(502)), **kwargs))
+    client.post(url + "/messages", json={"text": "counts 层不是原始计数"})
+    assert settle(client, sid)["status"] == "failed"
+    assert "_pending_qc" not in client.app.state.service.load(sid)

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+coverage/
+*.tsbuildinfo

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,28 @@
+# BRIDGE Web preview
+
+Private React/Vite client for the authenticated BRIDGE conversational preview. The server owns authentication, sessions, uploads, plans, execution and artifacts; this client only consumes the same-origin `/api` contract.
+
+## Commands
+
+Use Node.js 22.12 or newer.
+
+```bash
+npm ci
+npm test
+npm run build
+```
+
+For development, start the BRIDGE Web service on loopback port 8765, then:
+
+```bash
+npm run dev
+```
+
+Vite listens on `127.0.0.1:5173` and proxies `/api` to `127.0.0.1:8765`. Production static files are emitted to `web/dist` for FastAPI to serve.
+
+## Security and behavior
+
+- The login token is posted once and is never persisted by the client. Authenticated requests use the server cookie with same-origin credentials.
+- Messages are rendered as Markdown without raw HTML or model-authored images. Artifacts use registered same-origin session URLs; no arbitrary URL or HTML iframe is rendered.
+- The UI contains no fabricated scientific outcomes. Figures, tables, evidence and downloads appear only when returned by the server.
+- A proposed plan can be approved only by sending its exact server-provided plan ID and digest.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light" />
+    <meta name="theme-color" content="#ffffff" />
+    <title>BRIDGE</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,5952 @@
+{
+  "name": "bridge-web-preview",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bridge-web-preview",
+      "version": "0.1.0",
+      "dependencies": {
+        "@assistant-ui/react": "0.15.18",
+        "@assistant-ui/react-markdown": "0.14.14",
+        "lucide-react": "1.41.0",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
+        "remark-gfm": "4.0.1"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "7.0.1",
+        "@testing-library/react": "16.3.0",
+        "@testing-library/user-event": "14.6.7",
+        "@types/react": "19.2.18",
+        "@types/react-dom": "19.2.7",
+        "@vitejs/plugin-react": "6.1.1",
+        "jsdom": "30.0.1",
+        "typescript": "7.0.2",
+        "vite": "8.2.2",
+        "vitest": "5.0.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@assistant-ui/core": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.3.17.tgz",
+      "integrity": "sha512-qWiFVxFsnR4iBt6lZX8KFzf6gnL7uo5PQLgxZlbkUZn6dIzQByzmeFZfKp6vnVaPFN0B4qtc2hyCnDnWmtl7bw==",
+      "license": "MIT",
+      "dependencies": {
+        "assistant-stream": "^0.3.41",
+        "nanoid": "^6.0.1"
+      },
+      "peerDependencies": {
+        "@assistant-ui/store": "^0.3.12",
+        "@assistant-ui/tap": "^0.9.16",
+        "@types/react": "*",
+        "assistant-cloud": "^0.1.42",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "assistant-cloud": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/react": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.15.18.tgz",
+      "integrity": "sha512-hjjz+9+pY54jCyaCAO+c3Q2M715MGzvlJw2yx+jSqOZGc0znJmSId+6NXH8TwO3JX8lESHqQcVB1dWpFdAlq6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@assistant-ui/core": "^0.3.17",
+        "@assistant-ui/store": "^0.3.12",
+        "@assistant-ui/tap": "^0.9.16",
+        "assistant-cloud": "^0.1.43",
+        "assistant-stream": "^0.3.41",
+        "radix-ui": "^1.6.7",
+        "react-textarea-autosize": "^8.5.9",
+        "safe-content-frame": "^0.0.29",
+        "zod": "^4.5.4",
+        "zustand": "^5.0.15"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/react-markdown": {
+      "version": "0.14.14",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react-markdown/-/react-markdown-0.14.14.tgz",
+      "integrity": "sha512-hIydHkah5xUamtLBdWsezq/8b3xWvn1M3ixBXTUKfDihv3kBUPYH2AEgPlNrjSc9ZxYvoen9MzJDS+QTDaMOeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "^2.1.10",
+        "@radix-ui/react-use-callback-ref": "^1.1.4",
+        "@types/hast": "^3.0.5",
+        "classnames": "^2.5.1",
+        "react-markdown": "^10.1.0"
+      },
+      "peerDependencies": {
+        "@assistant-ui/react": "^0.15.0",
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/store": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.3.12.tgz",
+      "integrity": "sha512-ni0NWU8VLO55MZ5AUxljjKdYVRe9w2Fc7hgCO6Mb9F/Af3zD/fTOX9cS0m/IQhcmGlx8W4+GDunwbmkWMgeGEA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@assistant-ui/tap": "^0.9.16",
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/tap": {
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.9.16.tgz",
+      "integrity": "sha512-Wh0jJ0VMYudeRhXTt5Wn4e33cR9KueqOzIMprWF/W3AtAm/omAw0W7casWf6l+uNlFGkRnXUkzZp5vk6d8D7aA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+      "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accessible-icon": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.15.tgz",
+      "integrity": "sha512-WTQwcAvQf5sOcuUyi90lKPbhwcvQ+j55cjrSmeaN+L2vKU3DooOvlKw2MDeiJ5IkV5N905KW0/fGojKOBhD11A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-visually-hidden": "1.2.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.20.tgz",
+      "integrity": "sha512-jDhG9FvAEnlhnjrsINbNXcUa4G+L1KqSkJSunkbKEzFRcAb52jvM0PjPxPRvhe1HNc5F5yc0yzzWeeqlH4yBIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collapsible": "1.1.20",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.23.tgz",
+      "integrity": "sha512-VAYOiQRqj3GPpYJE0I9J+X8Ip05cyVlNdKOFeiGS2Ou1HHGfpl0BxOyZm6nmVDyU+W+NF3/XLzmjHmVGydhwgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dialog": "1.1.23",
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+      "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.15.tgz",
+      "integrity": "sha512-fy+dyVR+90nelK8rqIznFlxzx7uPcGbhxH8Nfr2bHb4UfSe+e3hklOC0luK0hDwVwnRX7xTRySpsrQVeW+/oNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.6.tgz",
+      "integrity": "sha512-4ULOTJ/mqy2hT9GlWa/MFHxHSvH3nJzHnZM1waNsc5Bonv7i70aNenghXmD97S6OJ81ekXONGGt4nT1r0PfEdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.11.tgz",
+      "integrity": "sha512-Gnptr9pDDQxD3hgq2dtPbtrp/c2qH1mBwIzw3X/ivrMb2e1t0jMTi606fVEqFPaQR1ggXIVQWKj3P2WW9v7zGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.20.tgz",
+      "integrity": "sha512-mcGesGplBnzN2sbvJETzpCNfSMyPnb29q1GRLU+Ib7bJrpIG2ywmRoh2V5VbA2uNvKikKUlVbAPks7JDjz4A8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.7.tgz",
+      "integrity": "sha512-CtXP35dxaB5T3zXSd+E3uHe/QpXcpYnZmxp6OaIbfthtfW4wyb77M23BG+bwIJDtsMwEP/YssdsmNyZu7jhWew==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+      "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+      "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+      "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.16.tgz",
+      "integrity": "sha512-Q4TLEn2A7TAypxwmd6R9EwrlXDvkfYSDMrq9/887AXAGh+G1rH+kYJKSTv+Si9Y0JPKTwKYv6PviAJosysNimA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-label": "2.1.15",
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.23.tgz",
+      "integrity": "sha512-H8qONfZd3ltrU3+jHCIgITbWo6e1iTKvP9DHdrvYbX48ooRM5FjEDTn16AMwdfuOGkWdZEhpl3PLL/Wk/AnHDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+      "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.15.tgz",
+      "integrity": "sha512-o/rdYEwZTTo5tjknnPeyQFU45kUC4i/XyeDPP+HGyi6XqpOP6Zf5Ya5vh/Yfe9Id5JiuWnnAx2XqIeD3UYZt0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+      "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar": {
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.24.tgz",
+      "integrity": "sha512-eeVs0vf7cuqXaM0qLQCPcufImiJNVBXdJDLu7ZGYl2732UH23Qat/foNGrr6vYV3/DdTsBqASoggUFgH14OcZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.22.tgz",
+      "integrity": "sha512-ou7iLEJ+yrhQndkkA4U21XIdS/CS45F4iXIkTZcb6/Ne9EMsOuDudVmCwmDnfFZZ+y1FZqXRNSIgBy+YMvZVZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.16.tgz",
+      "integrity": "sha512-Tj9P6ntAJEw52oq/F0AGknXR4XncxEt7XU47O3xJQOiWfLzEy3d9gtgKfvjSzGxzHkfL+VzvxGu2KTFsloJqXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.11.tgz",
+      "integrity": "sha512-4gvFnmDXu3dgj21CqsufzIameRvlRd4SBqaWhcrlrNhRo0Y5i/49AmRJYe1fdAM3G2VNBbmin4b0D6cdQocwgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-is-hydrated": "0.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.23.tgz",
+      "integrity": "sha512-mw58MrBlyHWFisTOYignD0vf/3gdcgAR+9of1s9G/38CbFiUwH1nCDkc0AUM9IrXFgN5Ue8n45j9WCgyM1sbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-rect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+      "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+      "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.16.tgz",
+      "integrity": "sha512-5XnomAsoZZCY+KNTxbIghpGqPruZvKFNlvcAljVAOdDRDsH4/OZQxhtwo5wdtoDM5R6MhJBb2sPnDuRFep3lzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.7.tgz",
+      "integrity": "sha512-cgYFEkntCxppHZgtSZ+7vh0wbZQ+IC7PPMw8DSnRG27B6kDd32/Zw0OJt7dGDigCoprMuWHjg2PvUn3PYvPFoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+      "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.18.tgz",
+      "integrity": "sha512-Zn5Cd171wxsO3Dfg8HaW6RifTb9CYTKQJHs/G4+LN1GfmJpaQMZQyQxMprVPHpaz7QY4l9BxK2JwQuzHsXC8nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+      "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.15.tgz",
+      "integrity": "sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+      "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.7.tgz",
+      "integrity": "sha512-48tB/4dn2UVLBCYhTu9AuR63IHl73l/qLbLgxd86noTUor4/K4LFDAcYjK+isP5313qxaFpjPVogE7+Y0/V3Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.21.tgz",
+      "integrity": "sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.23.tgz",
+      "integrity": "sha512-ofhyAsYaocRGOs/n0XWdUOSVzEAG6BfrMVM8z0c0kLEWY38w/0WuMFPTJP/HVaZPYkMvHZoKIIhNcjbTCBILPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+      "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+      "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-toggle": "1.1.18",
+        "@radix-ui/react-use-controllable-state": "1.2.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.19.tgz",
+      "integrity": "sha512-Ph0IvtYw4VB12ZnZg+YtrGs8yJQsnizwo/zu0R4Y/nWugtJzA7Pg1eWeuDR9+LSqn+xjamss+UOSOJJJ4gx8jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-separator": "1.1.15",
+        "@radix-ui/react-toggle-group": "1.1.19"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.16.tgz",
+      "integrity": "sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.5.tgz",
+      "integrity": "sha512-ge3ipobwSXTj4JyVtswQ7qZj0ZHdtbGuOno/LrgAAeSxtsJ6Vs4Gz5IkPH2bmqpjcLUFoqGhA/mueuIf63UXlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+      "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+      "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+      "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+      "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+      "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.7.tgz",
+      "integrity": "sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.1.tgz",
+      "integrity": "sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "oxc-transform-react": "^0.145.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "oxc-transform-react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/assistant-cloud": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.43.tgz",
+      "integrity": "sha512-dq9kvqTCBwZtIzypi0zYZpylCtd6Hd/DTANeoesUjMhZ3vMjqtLaLW8Ce8mbD07f8MBrT0iUvd6fTJRU8cV97A==",
+      "license": "MIT",
+      "dependencies": {
+        "assistant-stream": "^0.3.41"
+      }
+    },
+    "node_modules/assistant-stream": {
+      "version": "0.3.41",
+      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.41.tgz",
+      "integrity": "sha512-YyX9jPnxhKmzoJVzRNxcxfb66JbxTi+lwIyvq/N7hq1+6yaXYAeIfHU9PvAXWYfAS4zowJKj3rgCDGFtgpBMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "nanoid": "^6.0.1",
+        "secure-json-parse": "^4.1.0"
+      },
+      "peerDependencies": {
+        "ioredis": "^5.10.1 || ^6.0.0",
+        "redis": "^5.12.1"
+      },
+      "peerDependenciesMeta": {
+        "ioredis": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.41.0.tgz",
+      "integrity": "sha512-6lksP35l6KszDKUeRTi4LV7i6DEe0Yzl2ALJm9j4c5xEYN91GdW1xGsawGMOg2mgjF5GHBVX8pKX9kP+cWsP3Q==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-6.0.1.tgz",
+      "integrity": "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^22 || ^24 || >=26"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/radix-ui": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.7.tgz",
+      "integrity": "sha512-QBdhh1arIEUvPC0dQ5+nwWAxt7+N+oP/9jPwjJkGFoSk/sqxg32gJtSXGtFh8frAIcS6oC9cx2Q+7KYCQLOAeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-accessible-icon": "1.1.15",
+        "@radix-ui/react-accordion": "1.2.20",
+        "@radix-ui/react-alert-dialog": "1.1.23",
+        "@radix-ui/react-arrow": "1.1.15",
+        "@radix-ui/react-aspect-ratio": "1.1.15",
+        "@radix-ui/react-avatar": "1.2.6",
+        "@radix-ui/react-checkbox": "1.3.11",
+        "@radix-ui/react-collapsible": "1.1.20",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-context-menu": "2.3.7",
+        "@radix-ui/react-dialog": "1.1.23",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-dropdown-menu": "2.1.24",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-form": "0.1.16",
+        "@radix-ui/react-hover-card": "1.1.23",
+        "@radix-ui/react-label": "2.1.15",
+        "@radix-ui/react-menu": "2.1.24",
+        "@radix-ui/react-menubar": "1.1.24",
+        "@radix-ui/react-navigation-menu": "1.2.22",
+        "@radix-ui/react-one-time-password-field": "0.1.16",
+        "@radix-ui/react-password-toggle-field": "0.1.11",
+        "@radix-ui/react-popover": "1.1.23",
+        "@radix-ui/react-popper": "1.3.7",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-progress": "1.1.16",
+        "@radix-ui/react-radio-group": "1.4.7",
+        "@radix-ui/react-roving-focus": "1.1.19",
+        "@radix-ui/react-scroll-area": "1.2.18",
+        "@radix-ui/react-select": "2.3.7",
+        "@radix-ui/react-separator": "1.1.15",
+        "@radix-ui/react-slider": "1.4.7",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-switch": "1.3.7",
+        "@radix-ui/react-tabs": "1.1.21",
+        "@radix-ui/react-toast": "1.2.23",
+        "@radix-ui/react-toggle": "1.1.18",
+        "@radix-ui/react-toggle-group": "1.1.19",
+        "@radix-ui/react-toolbar": "1.1.19",
+        "@radix-ui/react-tooltip": "1.2.16",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-escape-keydown": "1.1.5",
+        "@radix-ui/react-use-is-hydrated": "0.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4",
+        "@radix-ui/react-visually-hidden": "1.2.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
+      }
+    },
+    "node_modules/safe-content-frame": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/safe-content-frame/-/safe-content-frame-0.0.29.tgz",
+      "integrity": "sha512-hVF+JVoCXl15ZVE8IRkIU9lU1BWErLbNDUVRPHtSe1jSTX/M1TG3a2ZFX3tgG/3iewml0qHxuuV1l7XySHIMoA==",
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.15.tgz",
+      "integrity": "sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "bridge-web-preview",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@assistant-ui/react": "0.15.18",
+    "@assistant-ui/react-markdown": "0.14.14",
+    "lucide-react": "1.41.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "remark-gfm": "4.0.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "7.0.1",
+    "@testing-library/react": "16.3.0",
+    "@testing-library/user-event": "14.6.7",
+    "@types/react": "19.2.18",
+    "@types/react-dom": "19.2.7",
+    "@vitejs/plugin-react": "6.1.1",
+    "jsdom": "30.0.1",
+    "typescript": "7.0.2",
+    "vite": "8.2.2",
+    "vitest": "5.0.0"
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,316 @@
+import { Menu, Plus } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { ApiError, api } from "./api";
+import { Conversation } from "./components/Conversation";
+import { LoginScreen } from "./components/LoginScreen";
+import { ResultsPane, WorkbenchDivider } from "./components/ResultsPane";
+import { Sidebar } from "./components/Sidebar";
+import { BridgeRuntimeProvider } from "./runtime/BridgeRuntimeProvider";
+import type { Session, SessionSummary } from "./types";
+
+const SELECTED_SESSION_KEY = "bridge.preview.selected-session.v1";
+const busyStatuses = new Set(["thinking", "running"]);
+const POLL_INTERVAL_MS = 1_250;
+const MAX_POLL_RETRY_MS = 8_000;
+
+function publicError(error: unknown) {
+  return error instanceof ApiError ? error.message : "The request could not be completed. Please try again.";
+}
+
+function LoadingScreen() {
+  return (
+    <main className="loading-screen" aria-live="polite">
+      <div className="brand">BRIDGE</div>
+      <div className="loading-line" />
+      <p>Opening private workspace…</p>
+    </main>
+  );
+}
+
+function EmptyConversation({
+  onOpenSidebar,
+  onCreate,
+  creating,
+}: {
+  onOpenSidebar: () => void;
+  onCreate: () => void;
+  creating: boolean;
+}) {
+  return (
+    <section className="conversation-pane empty-workspace">
+      <header className="conversation-header">
+        <button className="icon-button mobile-only" onClick={onOpenSidebar} aria-label="Open analyses">
+          <Menu aria-hidden="true" />
+        </button>
+        <div className="conversation-title">
+          <h1>New assessment</h1>
+        </div>
+      </header>
+      <div className="empty-workspace-content">
+        <h2>No analysis selected</h2>
+        <p>Create an analysis to begin a private conversation.</p>
+        <button onClick={onCreate} disabled={creating}>
+          <Plus aria-hidden="true" />
+          {creating ? "Creating…" : "New analysis"}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export default function App() {
+  const [authState, setAuthState] = useState<"checking" | "signed-out" | "signed-in">("checking");
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [session, setSession] = useState<Session | null>(null);
+  const [loginError, setLoginError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [action, setAction] = useState<"create" | "load" | "upload" | "approve" | "logout" | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [resultsWidth, setResultsWidth] = useState(() =>
+    Math.max(420, Math.min(620, Math.round(window.innerWidth * 0.4))),
+  );
+
+  const mergeSession = useCallback((next: Session) => {
+    setSession(next);
+    localStorage.setItem(SELECTED_SESSION_KEY, next.id);
+    setSessions((current) => {
+      const summary = { id: next.id, title: next.title, updated_at: next.updated_at };
+      return [summary, ...current.filter((item) => item.id !== next.id)].sort((a, b) =>
+        b.updated_at.localeCompare(a.updated_at),
+      );
+    });
+  }, []);
+
+  const handleAuthError = useCallback((error: unknown) => {
+    if (error instanceof ApiError && error.status === 401) {
+      setAuthState("signed-out");
+      setSession(null);
+      setSessions([]);
+    }
+  }, []);
+
+  const handleActionError = useCallback(
+    (error: unknown) => {
+      handleAuthError(error);
+      setNotice(publicError(error));
+    },
+    [handleAuthError],
+  );
+
+  const openWorkspace = useCallback(async () => {
+    const response = await api.listSessions();
+    setSessions(response.sessions);
+    setAuthState("signed-in");
+    const saved = localStorage.getItem(SELECTED_SESSION_KEY);
+    const selected = response.sessions.find((item) => item.id === saved) ?? response.sessions[0];
+    if (!selected) {
+      setSession(null);
+      return;
+    }
+    try {
+      mergeSession(await api.getSession(selected.id));
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 401) throw error;
+      setSession(null);
+      setNotice(publicError(error));
+    }
+  }, [mergeSession]);
+
+  useEffect(() => {
+    let active = true;
+    openWorkspace().catch((error: unknown) => {
+      if (!active) return;
+      if (error instanceof ApiError && error.status === 401) {
+        setAuthState("signed-out");
+      } else {
+        setAuthState("signed-out");
+        setLoginError(publicError(error));
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [openWorkspace]);
+
+  useEffect(() => {
+    const sessionId = session?.id;
+    if (!sessionId || !busyStatuses.has(session.status)) return;
+
+    let cancelled = false;
+    let controller: AbortController | null = null;
+    let timer: number | null = null;
+    let failedAttempts = 0;
+
+    const schedule = (delay: number) => {
+      timer = window.setTimeout(poll, delay);
+    };
+
+    const poll = async () => {
+      controller = new AbortController();
+      try {
+        const next = await api.getSession(sessionId, controller.signal);
+        if (cancelled) return;
+        failedAttempts = 0;
+        mergeSession(next);
+        if (busyStatuses.has(next.status)) schedule(POLL_INTERVAL_MS);
+      } catch (error) {
+        if (cancelled || (error as { name?: string }).name === "AbortError") return;
+        handleActionError(error);
+        if (error instanceof ApiError && error.status === 401) return;
+        failedAttempts += 1;
+        schedule(Math.min(MAX_POLL_RETRY_MS, POLL_INTERVAL_MS * 2 ** failedAttempts));
+      }
+    };
+
+    schedule(POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      controller?.abort();
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [handleActionError, mergeSession, session?.id, session?.status]);
+
+  const login = async (token: string) => {
+    setAction("load");
+    setLoginError(null);
+    try {
+      await api.login(token);
+      await openWorkspace();
+    } catch (error) {
+      setLoginError(publicError(error));
+      handleAuthError(error);
+    } finally {
+      setAction(null);
+    }
+  };
+
+  const logout = async () => {
+    setAction("logout");
+    setNotice(null);
+    try {
+      await api.logout();
+      localStorage.removeItem(SELECTED_SESSION_KEY);
+      setAuthState("signed-out");
+      setSession(null);
+      setSessions([]);
+    } catch (error) {
+      handleActionError(error);
+    } finally {
+      setAction(null);
+    }
+  };
+
+  const createSession = async () => {
+    setAction("create");
+    setNotice(null);
+    try {
+      mergeSession(await api.createSession());
+      setSidebarOpen(false);
+    } catch (error) {
+      handleActionError(error);
+    } finally {
+      setAction(null);
+    }
+  };
+
+  const selectSession = async (id: string) => {
+    if (session?.id === id) {
+      setSidebarOpen(false);
+      return;
+    }
+    setAction("load");
+    setNotice(null);
+    try {
+      mergeSession(await api.getSession(id));
+      setSidebarOpen(false);
+    } catch (error) {
+      handleActionError(error);
+    } finally {
+      setAction(null);
+    }
+  };
+
+  const upload = async (file: File) => {
+    if (!session) return;
+    setAction("upload");
+    setNotice(null);
+    try {
+      mergeSession(await api.upload(session.id, file));
+    } catch (error) {
+      handleActionError(error);
+    } finally {
+      setAction(null);
+    }
+  };
+
+  const approve = async () => {
+    if (!session?.plan) return;
+    setAction("approve");
+    setNotice(null);
+    try {
+      mergeSession(await api.approvePlan(session.id, session.plan.id, session.plan.digest));
+    } catch (error) {
+      handleActionError(error);
+    } finally {
+      setAction(null);
+    }
+  };
+
+  if (authState === "checking") return <LoadingScreen />;
+  if (authState === "signed-out") {
+    return <LoginScreen busy={action === "load"} error={loginError} onLogin={login} />;
+  }
+
+  const sessionBusy = session ? busyStatuses.has(session.status) : false;
+  return (
+    <main className="app-shell">
+      <Sidebar
+        sessions={sessions}
+        selectedId={session?.id ?? null}
+        open={sidebarOpen}
+        creating={action === "create"}
+        disabled={action !== null}
+        onClose={() => setSidebarOpen(false)}
+        onCreate={createSession}
+        onSelect={selectSession}
+        onLogout={logout}
+      />
+      <div className="workspace">
+        {session ? (
+          <BridgeRuntimeProvider
+            session={session}
+            disabled={sessionBusy || action !== null}
+            onSession={mergeSession}
+            onError={handleActionError}
+          >
+            <Conversation
+              session={session}
+              busy={sessionBusy || action !== null}
+              uploadBusy={action === "upload"}
+              approveBusy={action !== null}
+              onOpenSidebar={() => setSidebarOpen(true)}
+              onUpload={upload}
+              onApprove={approve}
+            />
+          </BridgeRuntimeProvider>
+        ) : (
+          <EmptyConversation
+            onOpenSidebar={() => setSidebarOpen(true)}
+            onCreate={createSession}
+            creating={action === "create"}
+          />
+        )}
+        <WorkbenchDivider width={resultsWidth} onWidth={setResultsWidth} />
+        <div className="results-wrap" style={{ width: resultsWidth }}>
+          <ResultsPane session={session} />
+        </div>
+      </div>
+      {notice ? (
+        <div className="notice" role="alert">
+          <span>{notice}</span>
+          <button onClick={() => setNotice(null)} aria-label="Dismiss">×</button>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,0 +1,77 @@
+import type { Session, SessionsResponse } from "./types";
+
+const GENERIC_ERROR = "The request could not be completed. Please try again.";
+
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number, detail: string) {
+    super(detail);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const headers = new Headers(init.headers);
+  if (init.body && !(init.body instanceof FormData) && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(path, {
+      ...init,
+      headers,
+      credentials: "same-origin",
+    });
+  } catch {
+    throw new ApiError(0, "The server is unavailable. Check the connection and try again.");
+  }
+
+  if (!response.ok) {
+    let detail = response.status === 401 ? "Authentication required." : GENERIC_ERROR;
+    try {
+      const body = (await response.json()) as { detail?: unknown };
+      if (typeof body.detail === "string" && body.detail.trim()) detail = body.detail;
+    } catch {
+      // Keep the stable public message for unknown or non-JSON failures.
+    }
+    throw new ApiError(response.status, detail);
+  }
+
+  return (await response.json()) as T;
+}
+
+export const api = {
+  health: () => request<{ status: "ok" }>("/api/health"),
+  login: (token: string) =>
+    request<{ authenticated: true }>("/api/login", {
+      method: "POST",
+      body: JSON.stringify({ token }),
+    }),
+  logout: () =>
+    request<{ authenticated: false }>("/api/logout", { method: "POST" }),
+  listSessions: () => request<SessionsResponse>("/api/sessions"),
+  createSession: () => request<Session>("/api/sessions", { method: "POST" }),
+  getSession: (id: string, signal?: AbortSignal) =>
+    request<Session>(`/api/sessions/${encodeURIComponent(id)}`, { signal }),
+  upload: (id: string, file: File) => {
+    const body = new FormData();
+    body.append("file", file);
+    return request<Session>(`/api/sessions/${encodeURIComponent(id)}/uploads`, {
+      method: "POST",
+      body,
+    });
+  },
+  sendMessage: (id: string, text: string) =>
+    request<Session>(`/api/sessions/${encodeURIComponent(id)}/messages`, {
+      method: "POST",
+      body: JSON.stringify({ text }),
+    }),
+  approvePlan: (id: string, planId: string, planDigest: string) =>
+    request<Session>(`/api/sessions/${encodeURIComponent(id)}/approve`, {
+      method: "POST",
+      body: JSON.stringify({ plan_id: planId, plan_digest: planDigest }),
+    }),
+};

--- a/web/src/components/Conversation.tsx
+++ b/web/src/components/Conversation.tsx
@@ -1,0 +1,162 @@
+import {
+  ComposerPrimitive,
+  MessagePrimitive,
+  ThreadPrimitive,
+} from "@assistant-ui/react";
+import { File, Menu, MoreVertical, Paperclip, Send, Square } from "lucide-react";
+import { type ChangeEvent, useRef } from "react";
+import type { Session } from "../types";
+import { MarkdownText } from "./MarkdownText";
+import { PlanCard } from "./PlanCard";
+import { SessionStatusMark } from "./StatusMark";
+
+type Props = {
+  session: Session;
+  busy: boolean;
+  uploadBusy: boolean;
+  approveBusy: boolean;
+  onOpenSidebar: () => void;
+  onUpload: (file: File) => void;
+  onApprove: () => void;
+};
+
+function UserMessage() {
+  return (
+    <MessagePrimitive.Root className="message message--user">
+      <div className="message-bubble message-bubble--user">
+        <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
+      </div>
+    </MessagePrimitive.Root>
+  );
+}
+
+function AssistantMessage() {
+  return (
+    <MessagePrimitive.Root className="message message--assistant">
+      <div className="assistant-mark" aria-hidden="true">
+        <Square />
+      </div>
+      <div className="message-bubble message-bubble--assistant">
+        <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
+      </div>
+    </MessagePrimitive.Root>
+  );
+}
+
+export function Conversation({
+  session,
+  busy,
+  uploadBusy,
+  approveBusy,
+  onOpenSidebar,
+  onUpload,
+  onApprove,
+}: Props) {
+  const fileInput = useRef<HTMLInputElement>(null);
+  const handleFile = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) onUpload(file);
+    event.target.value = "";
+  };
+
+  return (
+    <section className="conversation-pane" aria-label="Conversation">
+      <header className="conversation-header">
+        <button className="icon-button mobile-only" onClick={onOpenSidebar} aria-label="Open analyses">
+          <Menu aria-hidden="true" />
+        </button>
+        <div className="conversation-title">
+          <h1>{session.title || "Untitled analysis"}</h1>
+          <div className="conversation-status">
+            <SessionStatusMark status={session.status} />
+            <span>{session.status.replace("_", " ")}</span>
+          </div>
+        </div>
+        <a
+          className="icon-button"
+          href={`/api/sessions/${encodeURIComponent(session.id)}/transcript`}
+          download
+          aria-label="Download transcript"
+          title="Download transcript"
+        >
+          <MoreVertical aria-hidden="true" />
+        </a>
+      </header>
+      <ThreadPrimitive.Root className="thread-root">
+        <ThreadPrimitive.Viewport className="thread-viewport">
+          <div className="message-stack">
+            <ThreadPrimitive.Messages>
+              {({ message }) => (message.role === "user" ? <UserMessage /> : <AssistantMessage />)}
+            </ThreadPrimitive.Messages>
+            {session.messages.length === 0 ? (
+              <div className="conversation-empty">
+                <h2>Start a product assessment</h2>
+                <p>Upload an H5AD file, then describe the question you want BRIDGE to assess.</p>
+              </div>
+            ) : null}
+            {session.error ? (
+              <div className="session-error" role="alert">
+                {session.error}
+              </div>
+            ) : null}
+            {session.plan ? (
+              <PlanCard
+                plan={session.plan}
+                sessionStatus={session.status}
+                busy={approveBusy}
+                onApprove={onApprove}
+              />
+            ) : null}
+          </div>
+          <ThreadPrimitive.ViewportFooter className="composer-footer">
+            {session.uploads.length ? (
+              <div className="upload-list" aria-label="Uploaded files">
+                {session.uploads.map((upload) => (
+                  <div className="upload-chip" key={upload.id}>
+                    <File aria-hidden="true" />
+                    <span>{upload.name}</span>
+                    <small>{upload.kind}</small>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+            <ComposerPrimitive.Root className="composer">
+              <ComposerPrimitive.Input
+                className="composer-input"
+                placeholder="Ask about this analysis…"
+                rows={2}
+                submitMode="enter"
+                disabled={busy}
+                aria-label="Message"
+              />
+              <div className="composer-actions">
+                <input
+                  ref={fileInput}
+                  className="sr-only"
+                  type="file"
+                  accept=".h5ad,application/x-hdf5"
+                  onChange={handleFile}
+                  disabled={busy || uploadBusy}
+                  aria-label="Choose H5AD file"
+                />
+                <button
+                  className="composer-icon-button"
+                  type="button"
+                  onClick={() => fileInput.current?.click()}
+                  disabled={busy || uploadBusy}
+                  aria-label="Upload H5AD"
+                  title="Upload H5AD"
+                >
+                  <Paperclip aria-hidden="true" />
+                </button>
+                <ComposerPrimitive.Send className="composer-send" aria-label="Send message">
+                  <Send aria-hidden="true" />
+                </ComposerPrimitive.Send>
+              </div>
+            </ComposerPrimitive.Root>
+          </ThreadPrimitive.ViewportFooter>
+        </ThreadPrimitive.Viewport>
+      </ThreadPrimitive.Root>
+    </section>
+  );
+}

--- a/web/src/components/LoginScreen.tsx
+++ b/web/src/components/LoginScreen.tsx
@@ -1,0 +1,55 @@
+import { ArrowRight, LockKeyhole } from "lucide-react";
+import { type FormEvent, useState } from "react";
+
+type Props = {
+  busy: boolean;
+  error: string | null;
+  onLogin: (token: string) => Promise<void>;
+};
+
+export function LoginScreen({ busy, error, onLogin }: Props) {
+  const [token, setToken] = useState("");
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!token.trim() || busy) return;
+    await onLogin(token);
+  };
+
+  return (
+    <main className="login-shell">
+      <section className="login-card" aria-labelledby="login-title">
+        <div className="brand">BRIDGE</div>
+        <div className="login-icon" aria-hidden="true">
+          <LockKeyhole />
+        </div>
+        <h1 id="login-title">Private research preview</h1>
+        <p>Enter the access token provided by the preview operator.</p>
+        <form onSubmit={submit}>
+          <label htmlFor="access-token">Access token</label>
+          <div className="login-input-row">
+            <input
+              id="access-token"
+              name="token"
+              type="password"
+              autoComplete="current-password"
+              value={token}
+              onChange={(event) => setToken(event.target.value)}
+              disabled={busy}
+              autoFocus
+            />
+            <button type="submit" disabled={busy || !token.trim()} aria-label="Sign in">
+              <ArrowRight aria-hidden="true" />
+            </button>
+          </div>
+          {error ? (
+            <p className="form-error" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </form>
+        <p className="login-footnote">Your token stays in this sign-in request and is not stored in the browser.</p>
+      </section>
+    </main>
+  );
+}

--- a/web/src/components/MarkdownText.tsx
+++ b/web/src/components/MarkdownText.tsx
@@ -1,0 +1,13 @@
+import { lazy, Suspense } from "react";
+
+const MarkdownTextImpl = lazy(() =>
+  import("./MarkdownTextImpl").then((module) => ({ default: module.MarkdownTextImpl })),
+);
+
+export function MarkdownText() {
+  return (
+    <Suspense fallback={<span className="message-loading">Loading message…</span>}>
+      <MarkdownTextImpl />
+    </Suspense>
+  );
+}

--- a/web/src/components/MarkdownTextImpl.tsx
+++ b/web/src/components/MarkdownTextImpl.tsx
@@ -1,0 +1,19 @@
+import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
+import remarkGfm from "remark-gfm";
+
+export function MarkdownTextImpl() {
+  return (
+    <MarkdownTextPrimitive
+      className="message-markdown"
+      remarkPlugins={[remarkGfm]}
+      components={{
+        img: () => null,
+        a: ({ children, ...props }) => (
+          <a {...props} target="_blank" rel="noreferrer">
+            {children}
+          </a>
+        ),
+      }}
+    />
+  );
+}

--- a/web/src/components/PlanCard.tsx
+++ b/web/src/components/PlanCard.tsx
@@ -1,0 +1,60 @@
+import { Database, Network, PanelsTopLeft } from "lucide-react";
+import type { Plan, SessionStatus } from "../types";
+import { StepStatusMark } from "./StatusMark";
+
+type Props = {
+  plan: Plan;
+  sessionStatus: SessionStatus;
+  busy: boolean;
+  onApprove: () => void;
+};
+
+const StepIcon = ({ index }: { index: number }) => {
+  const Icon = index % 3 === 0 ? Database : index % 3 === 1 ? Network : PanelsTopLeft;
+  return <Icon aria-hidden="true" />;
+};
+
+const planActionLabel = (plan: Plan, status: SessionStatus) => {
+  if (plan.status === "completed") return "Analysis completed";
+  if (plan.status === "failed") return "Analysis failed";
+  if (status === "running") return "Analysis running…";
+  if (plan.status === "approved") return "Analysis approved";
+  return "Confirm analysis";
+};
+
+export function PlanCard({ plan, sessionStatus, busy, onApprove }: Props) {
+  const approvable = plan.status === "proposed" && sessionStatus === "awaiting_approval";
+  return (
+    <section className="plan-card" aria-labelledby={`plan-${plan.id}-title`}>
+      <header>
+        <div>
+          <h2 id={`plan-${plan.id}-title`}>Analysis plan</h2>
+          {plan.summary ? <p>{plan.summary}</p> : null}
+        </div>
+        <span className={`plan-state plan-state--${plan.status}`}>{plan.status}</span>
+      </header>
+      <ol>
+        {plan.steps.map((step, index) => (
+          <li key={step.id}>
+            <StepIcon index={index} />
+            <div className="plan-step-copy">
+              <span>{step.label}</span>
+              {step.reason ? <small>{step.reason}</small> : null}
+            </div>
+            <span className={`step-state step-state--${step.status}`}>
+              <StepStatusMark status={step.status} />
+              <span>{step.status}</span>
+            </span>
+          </li>
+        ))}
+      </ol>
+      <button
+        className="approve-button"
+        onClick={onApprove}
+        disabled={!approvable || busy}
+      >
+        {planActionLabel(plan, sessionStatus)}
+      </button>
+    </section>
+  );
+}

--- a/web/src/components/ResultsPane.tsx
+++ b/web/src/components/ResultsPane.tsx
@@ -1,0 +1,340 @@
+import { Download, FileText, Image as ImageIcon, Table2 } from "lucide-react";
+import { type KeyboardEvent, type PointerEvent, useEffect, useMemo, useState } from "react";
+import type { Artifact, ArtifactKind, Session } from "../types";
+
+const tabs: { kind: ArtifactKind; label: string }[] = [
+  { kind: "figure", label: "Figures" },
+  { kind: "table", label: "Tables" },
+  { kind: "evidence", label: "Evidence" },
+  { kind: "download", label: "Downloads" },
+];
+
+function artifactUrl(sessionId: string, artifactId: string) {
+  return `/api/sessions/${encodeURIComponent(sessionId)}/artifacts/${encodeURIComponent(artifactId)}`;
+}
+
+const MAX_ARTIFACT_PREVIEW_BYTES = 200_000;
+
+export async function readBoundedText(response: Response, maxBytes = MAX_ARTIFACT_PREVIEW_BYTES) {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("stream_unavailable");
+  const decoder = new TextDecoder();
+  let text = "";
+  let bytesRead = 0;
+  let truncated = false;
+
+  try {
+    while (bytesRead < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) {
+        text += decoder.decode();
+        return { text, truncated };
+      }
+      const remaining = maxBytes - bytesRead;
+      const chunk = value.byteLength > remaining ? value.subarray(0, remaining) : value;
+      text += decoder.decode(chunk, { stream: true });
+      bytesRead += chunk.byteLength;
+      if (value.byteLength > remaining || bytesRead === maxBytes) {
+        truncated = true;
+        await reader.cancel();
+        break;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  text += decoder.decode();
+  return { text, truncated };
+}
+
+function figureGroupKey(artifact: Artifact) {
+  return `${artifact.tool_id}:${artifact.name.replace(/\.(?:svg|png)$/i, "")}`;
+}
+
+function isSvg(artifact: Artifact) {
+  return artifact.media_type === "image/svg+xml" || /\.svg$/i.test(artifact.name);
+}
+
+function artifactsForTab(session: Session | null, kind: ArtifactKind) {
+  if (!session) return [];
+  if (kind === "download") {
+    return session.artifacts;
+  }
+  if (kind !== "figure") return session.artifacts.filter((artifact) => artifact.kind === kind);
+
+  const figures = new Map<string, Artifact>();
+  for (const artifact of session.artifacts) {
+    if (artifact.kind !== "figure") continue;
+    const key = figureGroupKey(artifact);
+    const current = figures.get(key);
+    if (!current || (!isSvg(current) && isSvg(artifact))) figures.set(key, artifact);
+  }
+  return Array.from(figures.values());
+}
+
+function parseDelimited(value: string, delimiter: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let quoted = false;
+  for (let index = 0; index < value.length && rows.length < 101; index += 1) {
+    const char = value[index];
+    if (char === "\"") {
+      if (quoted && value[index + 1] === "\"") {
+        cell += "\"";
+        index += 1;
+      } else {
+        quoted = !quoted;
+      }
+    } else if (char === delimiter && !quoted) {
+      row.push(cell);
+      cell = "";
+    } else if ((char === "\n" || char === "\r") && !quoted) {
+      if (char === "\r" && value[index + 1] === "\n") index += 1;
+      row.push(cell);
+      rows.push(row.slice(0, 24));
+      row = [];
+      cell = "";
+    } else {
+      cell += char;
+    }
+  }
+  if ((cell || row.length) && rows.length < 101) {
+    row.push(cell);
+    rows.push(row.slice(0, 24));
+  }
+  return rows;
+}
+
+function TablePreview({ text, mediaType }: { text: string; mediaType: string }) {
+  const rows = useMemo(() => {
+    if (mediaType.includes("json")) {
+      try {
+        const parsed = JSON.parse(text) as unknown;
+        if (Array.isArray(parsed) && parsed.every((item) => item && typeof item === "object")) {
+          const headers = Array.from(
+            new Set(parsed.slice(0, 100).flatMap((item) => Object.keys(item as object))),
+          ).slice(0, 24);
+          return [
+            headers,
+            ...parsed
+              .slice(0, 100)
+              .map((item) => headers.map((header) => String((item as Record<string, unknown>)[header] ?? ""))),
+          ];
+        }
+      } catch {
+        return [];
+      }
+      return [];
+    }
+    return parseDelimited(text, mediaType.includes("csv") ? "," : "\t");
+  }, [mediaType, text]);
+
+  if (!rows.length) return <pre className="artifact-text">{text}</pre>;
+  return (
+    <div className="table-scroll">
+      <table>
+        <thead>
+          <tr>{rows[0].map((cell, index) => <th key={index}>{cell}</th>)}</tr>
+        </thead>
+        <tbody>
+          {rows.slice(1).map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {row.map((cell, cellIndex) => <td key={cellIndex}>{cell}</td>)}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function TextArtifact({ sessionId, artifact }: { sessionId: string; artifact: Artifact }) {
+  const [state, setState] = useState<{
+    loading: boolean;
+    text: string;
+    truncated: boolean;
+    error: string | null;
+  }>({
+    loading: true,
+    text: "",
+    truncated: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ loading: true, text: "", truncated: false, error: null });
+    fetch(artifactUrl(sessionId, artifact.id), {
+      credentials: "same-origin",
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error();
+        const { text, truncated } = await readBoundedText(response);
+        setState({ loading: false, text, truncated, error: null });
+      })
+      .catch((error: unknown) => {
+        if ((error as { name?: string }).name !== "AbortError") {
+          setState({
+            loading: false,
+            text: "",
+            truncated: false,
+            error: "This artifact could not be previewed. Download it to inspect the original.",
+          });
+        }
+      });
+    return () => controller.abort();
+  }, [artifact.id, sessionId]);
+
+  if (state.loading) return <p className="artifact-loading">Loading preview…</p>;
+  if (state.error) return <p className="artifact-error">{state.error}</p>;
+  return (
+    <>
+      {state.truncated ? (
+        <p className="artifact-truncated">Preview truncated. Download the original artifact for complete content.</p>
+      ) : null}
+      {artifact.kind === "table" ? (
+        <TablePreview text={state.text} mediaType={artifact.media_type} />
+      ) : (
+        <pre className="artifact-text">{state.text}</pre>
+      )}
+    </>
+  );
+}
+
+function EmptyResults({ kind }: { kind: ArtifactKind }) {
+  const Icon =
+    kind === "figure" ? ImageIcon : kind === "table" ? Table2 : kind === "download" ? Download : FileText;
+  const label = tabs.find((tab) => tab.kind === kind)?.label.toLowerCase();
+  return (
+    <div className="results-empty">
+      <div className="results-empty-icon">
+        <Icon aria-hidden="true" />
+      </div>
+      <h2>{kind === "figure" ? "Results will appear here" : `No ${label} yet`}</h2>
+      <p>
+        {kind === "figure"
+          ? "Figures are generated by the analysis tools."
+          : "Results produced by approved analysis tools will appear here."}
+      </p>
+    </div>
+  );
+}
+
+export function ResultsPane({ session }: { session: Session | null }) {
+  const [activeTab, setActiveTab] = useState<ArtifactKind>("figure");
+  const artifacts = useMemo(() => artifactsForTab(session, activeTab), [activeTab, session]);
+
+  return (
+    <section className="results-pane" aria-label="Analysis results">
+      <header className="results-header">
+        <h1>Results</h1>
+      </header>
+      <div className="result-tabs" role="tablist" aria-label="Result type">
+        {tabs.map((tab) => {
+          const count = artifactsForTab(session, tab.kind).length;
+          return (
+            <button
+              key={tab.kind}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab.kind}
+              className={activeTab === tab.kind ? "result-tab--active" : ""}
+              onClick={() => setActiveTab(tab.kind)}
+            >
+              {tab.label}
+              {count ? <span>{count}</span> : null}
+            </button>
+          );
+        })}
+      </div>
+      <div className="results-content" role="tabpanel">
+        {!session || !artifacts.length ? (
+          <EmptyResults kind={activeTab} />
+        ) : (
+          <div className={`artifact-grid artifact-grid--${activeTab}`}>
+            {artifacts.map((artifact) => {
+              const url = artifactUrl(session.id, artifact.id);
+              return (
+                <article className="artifact-card" key={artifact.id}>
+                  <header>
+                    <div>
+                      <h2>{artifact.name}</h2>
+                      <p>{artifact.tool_id}</p>
+                    </div>
+                    <a href={url} download={artifact.name} aria-label={`Download ${artifact.name}`}>
+                      <Download aria-hidden="true" />
+                    </a>
+                  </header>
+                  {activeTab === "figure" ? (
+                    <img src={url} alt={artifact.name} />
+                  ) : activeTab === "download" ? (
+                    <a className="download-row" href={url} download={artifact.name}>
+                      <FileText aria-hidden="true" />
+                      <span>Download original file</span>
+                      <Download aria-hidden="true" />
+                    </a>
+                  ) : (
+                    <TextArtifact sessionId={session.id} artifact={artifact} />
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+type DividerProps = {
+  width: number;
+  onWidth: (width: number) => void;
+};
+
+function clampResultsWidth(width: number) {
+  return Math.max(360, Math.min(Math.max(360, window.innerWidth - 560), width));
+}
+
+export function WorkbenchDivider({ width, onWidth }: DividerProps) {
+  const startResize = (event: PointerEvent<HTMLDivElement>) => {
+    event.currentTarget.setPointerCapture(event.pointerId);
+    const startX = event.clientX;
+    const startWidth = width;
+    const move = (moveEvent: globalThis.PointerEvent) => {
+      onWidth(clampResultsWidth(startWidth - (moveEvent.clientX - startX)));
+    };
+    const finish = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", finish);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", finish);
+  };
+
+  const resizeWithKeyboard = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    onWidth(clampResultsWidth(width + (event.key === "ArrowLeft" ? 24 : -24)));
+  };
+
+  return (
+    <div
+      className="workbench-divider"
+      role="separator"
+      aria-label="Resize results"
+      aria-orientation="vertical"
+      tabIndex={0}
+      onPointerDown={startResize}
+      onKeyDown={resizeWithKeyboard}
+    >
+      <span>
+        <i />
+        <i />
+        <i />
+      </span>
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,0 +1,67 @@
+import { LogOut, MessageSquare, Plus, X } from "lucide-react";
+import type { SessionSummary } from "../types";
+
+type Props = {
+  sessions: SessionSummary[];
+  selectedId: string | null;
+  open: boolean;
+  creating: boolean;
+  disabled: boolean;
+  onClose: () => void;
+  onCreate: () => void;
+  onSelect: (id: string) => void;
+  onLogout: () => void;
+};
+
+export function Sidebar({
+  sessions,
+  selectedId,
+  open,
+  creating,
+  disabled,
+  onClose,
+  onCreate,
+  onSelect,
+  onLogout,
+}: Props) {
+  return (
+    <>
+      {open ? <button className="sidebar-scrim" aria-label="Close analyses" onClick={onClose} /> : null}
+      <aside className={`sidebar ${open ? "sidebar--open" : ""}`} aria-label="Analysis history">
+        <div className="sidebar-brand-row">
+          <div className="brand">BRIDGE</div>
+          <button className="icon-button mobile-only" onClick={onClose} aria-label="Close analyses">
+            <X aria-hidden="true" />
+          </button>
+        </div>
+        <button className="new-analysis" onClick={onCreate} disabled={disabled}>
+          <Plus aria-hidden="true" />
+          <span>{creating ? "Creating…" : "New analysis"}</span>
+        </button>
+        <div className="sidebar-label">Sessions</div>
+        <nav className="session-list">
+          {sessions.length ? (
+            sessions.map((session) => (
+              <button
+                key={session.id}
+                className={`session-row ${selectedId === session.id ? "session-row--active" : ""}`}
+                onClick={() => onSelect(session.id)}
+                aria-current={selectedId === session.id ? "page" : undefined}
+                disabled={disabled}
+              >
+                <MessageSquare aria-hidden="true" />
+                <span>{session.title || "Untitled analysis"}</span>
+              </button>
+            ))
+          ) : (
+            <p className="empty-history">No analyses yet.</p>
+          )}
+        </nav>
+        <button className="sidebar-logout" onClick={onLogout} disabled={disabled}>
+          <LogOut aria-hidden="true" />
+          <span>Sign out</span>
+        </button>
+      </aside>
+    </>
+  );
+}

--- a/web/src/components/StatusMark.tsx
+++ b/web/src/components/StatusMark.tsx
@@ -1,0 +1,27 @@
+import { Check, CircleAlert, CircleDashed, LoaderCircle, Minus } from "lucide-react";
+import type { PlanStep, SessionStatus } from "../types";
+
+export function SessionStatusMark({ status }: { status: SessionStatus }) {
+  const content =
+    status === "thinking" || status === "running" ? (
+      <LoaderCircle aria-hidden="true" className="spin" />
+    ) : status === "failed" ? (
+      <CircleAlert aria-hidden="true" />
+    ) : (
+      <span aria-hidden="true" className="status-dot" />
+    );
+  return (
+    <span className={`session-status session-status--${status}`} title={status.replace("_", " ")}>
+      {content}
+      <span className="sr-only">{status.replace("_", " ")}</span>
+    </span>
+  );
+}
+
+export function StepStatusMark({ status }: { status: PlanStep["status"] }) {
+  if (status === "running") return <LoaderCircle aria-label="Running" className="spin" />;
+  if (status === "succeeded") return <Check aria-label="Succeeded" />;
+  if (status === "failed") return <CircleAlert aria-label="Failed" />;
+  if (status === "skipped") return <Minus aria-label="Skipped" />;
+  return <CircleDashed aria-label="Pending" />;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/web/src/runtime/BridgeRuntimeProvider.tsx
+++ b/web/src/runtime/BridgeRuntimeProvider.tsx
@@ -1,0 +1,61 @@
+import {
+  AssistantRuntimeProvider,
+  type AppendMessage,
+  type ThreadMessageLike,
+  useExternalStoreRuntime,
+} from "@assistant-ui/react";
+import { type ReactNode, useCallback } from "react";
+import { api } from "../api";
+import type { Message, Session } from "../types";
+
+type Props = {
+  session: Session;
+  disabled: boolean;
+  onSession: (session: Session) => void;
+  onError: (error: unknown) => void;
+  children: ReactNode;
+};
+
+const convertMessage = (message: Message): ThreadMessageLike => ({
+  id: message.id,
+  role: message.role,
+  content: [{ type: "text", text: message.content }],
+  createdAt: new Date(message.created_at),
+});
+
+export function BridgeRuntimeProvider({
+  session,
+  disabled,
+  onSession,
+  onError,
+  children,
+}: Props) {
+  const onNew = useCallback(
+    async (message: AppendMessage) => {
+      const text = message.content
+        .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
+        .map((part) => part.text)
+        .join("\n")
+        .trim();
+      if (!text || disabled) return;
+
+      try {
+        onSession(await api.sendMessage(session.id, text));
+      } catch (error) {
+        onError(error);
+        throw error;
+      }
+    },
+    [disabled, onError, onSession, session.id],
+  );
+
+  const runtime = useExternalStoreRuntime({
+    messages: session.messages,
+    convertMessage,
+    isRunning: session.status === "thinking" || session.status === "running",
+    isSendDisabled: disabled,
+    onNew,
+  });
+
+  return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,1503 @@
+:root {
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #111315;
+  background: #ffffff;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  --border: #d9dde2;
+  --border-strong: #c7ccd3;
+  --muted: #676d77;
+  --soft: #f5f6f7;
+  --sidebar: #fafafa;
+  --ink: #111315;
+  --danger: #a12b2b;
+  --success: #2c6a4b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  min-width: 320px;
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow: hidden;
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+button {
+  color: inherit;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+[role="separator"]:focus-visible {
+  outline: 2px solid #111315;
+  outline-offset: 2px;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.brand {
+  font-size: 29px;
+  font-weight: 650;
+  letter-spacing: 0.15em;
+}
+
+.app-shell {
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+  background: #fff;
+}
+
+.sidebar {
+  position: relative;
+  z-index: 20;
+  display: flex;
+  width: 278px;
+  min-width: 278px;
+  height: 100%;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  background: var(--sidebar);
+  padding: 27px 22px 20px;
+}
+
+.sidebar-brand-row {
+  display: flex;
+  min-height: 38px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 7px;
+}
+
+.new-analysis {
+  display: flex;
+  width: 100%;
+  height: 50px;
+  align-items: center;
+  gap: 18px;
+  margin-top: 28px;
+  padding: 0 19px;
+  border: 1px solid var(--border-strong);
+  border-radius: 9px;
+  background: #fff;
+  font-size: 15px;
+  font-weight: 520;
+  text-align: left;
+  cursor: pointer;
+}
+
+.new-analysis:hover:not(:disabled) {
+  border-color: #8d929a;
+  background: #fdfdfd;
+}
+
+.new-analysis svg {
+  width: 21px;
+  height: 21px;
+  stroke-width: 1.8;
+}
+
+.sidebar-label {
+  margin: 41px 8px 12px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.session-list {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+
+.session-row {
+  position: relative;
+  display: flex;
+  min-height: 54px;
+  width: 100%;
+  align-items: center;
+  gap: 13px;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  padding: 10px 11px;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.session-row::before {
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  left: -12px;
+  width: 2px;
+  border-radius: 2px;
+  background: transparent;
+  content: "";
+}
+
+.session-row:hover {
+  background: #f0f1f2;
+}
+
+.session-row--active {
+  background: #edeef0;
+  font-weight: 570;
+}
+
+.session-row--active::before {
+  background: var(--ink);
+}
+
+.session-row svg {
+  width: 19px;
+  height: 19px;
+  flex: 0 0 auto;
+  stroke-width: 1.7;
+}
+
+.session-row span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.empty-history {
+  margin: 10px 9px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.sidebar-logout {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  width: 100%;
+  min-height: 42px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  padding: 0 10px;
+  color: #4d535b;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.sidebar-logout:hover {
+  background: #f0f1f2;
+}
+
+.sidebar-logout svg {
+  width: 17px;
+  height: 17px;
+}
+
+.sidebar-scrim,
+.mobile-only {
+  display: none;
+}
+
+.workspace {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  height: 100%;
+}
+
+.conversation-pane {
+  display: flex;
+  min-width: 510px;
+  flex: 1;
+  flex-direction: column;
+  background: #fff;
+}
+
+.conversation-header,
+.results-header {
+  display: flex;
+  height: 81px;
+  min-height: 81px;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+}
+
+.conversation-header {
+  justify-content: space-between;
+  padding: 0 24px 0 30px;
+}
+
+.conversation-title {
+  min-width: 0;
+}
+
+.conversation-title h1,
+.results-header h1 {
+  overflow: hidden;
+  margin: 0;
+  font-size: 21px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conversation-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: capitalize;
+}
+
+.session-status {
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  align-items: center;
+  justify-content: center;
+}
+
+.session-status svg {
+  width: 12px;
+  height: 12px;
+}
+
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #92979e;
+}
+
+.session-status--awaiting_approval .status-dot {
+  background: #8a6725;
+}
+
+.session-status--failed {
+  color: var(--danger);
+}
+
+.icon-button:not(.mobile-only) {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: #2a2d31;
+  cursor: pointer;
+}
+
+.icon-button:hover {
+  background: var(--soft);
+}
+
+.icon-button svg {
+  width: 20px;
+  height: 20px;
+  stroke-width: 1.8;
+}
+
+.thread-root {
+  min-height: 0;
+  flex: 1;
+}
+
+.thread-viewport {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 32px 26px 0;
+}
+
+.message-stack {
+  display: flex;
+  width: min(100%, 620px);
+  flex: 1 0 auto;
+  flex-direction: column;
+  gap: 26px;
+  margin: 0 auto;
+}
+
+.message {
+  display: flex;
+  width: 100%;
+}
+
+.message--user {
+  justify-content: flex-end;
+}
+
+.message--assistant {
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 16px;
+}
+
+.message-bubble {
+  max-width: 84%;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+.message-bubble--user {
+  background: #f3f4f5;
+}
+
+.message-bubble--assistant {
+  background: #fff;
+}
+
+.assistant-mark {
+  display: flex;
+  width: 37px;
+  height: 37px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: #151719;
+  color: #fff;
+}
+
+.assistant-mark svg {
+  width: 16px;
+  height: 16px;
+  stroke-width: 2.2;
+}
+
+.message-markdown > :first-child {
+  margin-top: 0;
+}
+
+.message-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.message-markdown p,
+.message-markdown ul,
+.message-markdown ol,
+.message-markdown blockquote {
+  margin: 0 0 0.7em;
+}
+
+.message-markdown ul,
+.message-markdown ol {
+  padding-left: 1.3em;
+}
+
+.message-markdown a {
+  color: inherit;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.message-markdown pre,
+.message-markdown code {
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 0.9em;
+}
+
+.message-markdown pre {
+  max-width: 100%;
+  overflow-x: auto;
+  border-radius: 6px;
+  background: #f4f5f6;
+  padding: 10px;
+}
+
+.conversation-empty {
+  margin: auto;
+  padding: 80px 20px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.conversation-empty h2,
+.empty-workspace-content h2 {
+  margin: 0 0 9px;
+  color: var(--ink);
+  font-size: 20px;
+  font-weight: 640;
+}
+
+.conversation-empty p,
+.empty-workspace-content p {
+  max-width: 390px;
+  margin: 0 auto;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.session-error {
+  border-left: 2px solid var(--danger);
+  background: #fff7f7;
+  padding: 11px 13px;
+  color: #772020;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.plan-card {
+  overflow: hidden;
+  width: calc(100% - 53px);
+  max-width: 540px;
+  margin-left: 53px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.plan-card > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 17px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.plan-card h2 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.plan-card header p {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.plan-state {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.plan-state--completed {
+  color: var(--success);
+}
+
+.plan-state--failed {
+  color: var(--danger);
+}
+
+.plan-card ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.plan-card li {
+  display: grid;
+  min-height: 58px;
+  grid-template-columns: 22px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 13px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.plan-card li > svg {
+  width: 18px;
+  height: 18px;
+  color: #737983;
+  stroke-width: 1.7;
+}
+
+.plan-step-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 13px;
+}
+
+.plan-step-copy small {
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.step-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: capitalize;
+}
+
+.step-state svg {
+  width: 13px;
+  height: 13px;
+}
+
+.step-state--succeeded {
+  color: var(--success);
+}
+
+.step-state--failed {
+  color: var(--danger);
+}
+
+.approve-button {
+  width: calc(100% - 24px);
+  min-height: 44px;
+  margin: 12px;
+  border: 1px solid var(--ink);
+  border-radius: 7px;
+  background: var(--ink);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.approve-button:hover:not(:disabled) {
+  background: #2a2c2f;
+}
+
+.approve-button:disabled {
+  border-color: #d8dade;
+  background: #eceef0;
+  color: #777d85;
+}
+
+.composer-footer {
+  position: sticky;
+  bottom: 0;
+  width: min(100%, 650px);
+  margin: 36px auto 0;
+  background: linear-gradient(to bottom, rgba(255,255,255,0), #fff 26px);
+  padding: 32px 0 24px;
+}
+
+.upload-list {
+  display: flex;
+  max-height: 98px;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: 0 0 8px;
+  overflow-y: auto;
+}
+
+.upload-chip {
+  display: grid;
+  max-width: 100%;
+  grid-template-columns: auto minmax(0, auto) auto;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #fff;
+  padding: 7px 9px;
+  color: #4d535b;
+  font-size: 12px;
+}
+
+.upload-chip svg {
+  width: 15px;
+  height: 15px;
+}
+
+.upload-chip span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.upload-chip small {
+  color: #858b94;
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.composer {
+  min-height: 118px;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: 9px;
+  background: #fff;
+}
+
+.composer:focus-within {
+  border-color: #7c8188;
+  box-shadow: 0 0 0 1px #7c8188;
+}
+
+.composer-input {
+  display: block;
+  width: 100%;
+  min-height: 68px;
+  resize: none;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  padding: 16px 18px 6px;
+  color: var(--ink);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.composer-input::placeholder {
+  color: #858b94;
+}
+
+.composer-input:disabled {
+  color: #8f949b;
+}
+
+.composer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 11px 10px;
+}
+
+.composer-icon-button,
+.composer-send {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #666c75;
+  cursor: pointer;
+}
+
+.composer-icon-button:hover:not(:disabled),
+.composer-send:hover:not(:disabled) {
+  background: #f1f2f3;
+  color: var(--ink);
+}
+
+.composer-icon-button:disabled,
+.composer-send:disabled {
+  color: #c4c8cd;
+}
+
+.composer-icon-button svg,
+.composer-send svg {
+  width: 22px;
+  height: 22px;
+  stroke-width: 1.8;
+}
+
+.workbench-divider {
+  position: relative;
+  z-index: 4;
+  display: flex;
+  width: 7px;
+  min-width: 7px;
+  align-items: center;
+  justify-content: center;
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  background: #fff;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.workbench-divider > span {
+  display: flex;
+  width: 21px;
+  height: 55px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  border: 1px solid var(--border-strong);
+  border-radius: 11px;
+  background: #fff;
+}
+
+.workbench-divider i {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: #5f656e;
+}
+
+.results-wrap {
+  min-width: 360px;
+  max-width: calc(100vw - 788px);
+  height: 100%;
+}
+
+.results-pane {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  background: #fff;
+}
+
+.results-header {
+  padding: 0 29px;
+}
+
+.result-tabs {
+  display: flex;
+  min-height: 51px;
+  gap: 28px;
+  align-items: flex-end;
+  border-bottom: 1px solid var(--border);
+  padding: 0 23px;
+  overflow-x: auto;
+}
+
+.result-tabs button {
+  position: relative;
+  display: inline-flex;
+  height: 51px;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  padding: 0 3px;
+  color: #4d535b;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.result-tabs button::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  background: transparent;
+  content: "";
+}
+
+.result-tabs button.result-tab--active {
+  color: var(--ink);
+  font-weight: 570;
+}
+
+.result-tabs button.result-tab--active::after {
+  background: var(--ink);
+}
+
+.result-tabs button span {
+  min-width: 18px;
+  border-radius: 9px;
+  background: #eff0f1;
+  padding: 1px 5px;
+  font-size: 10px;
+  text-align: center;
+}
+
+.results-content {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.results-empty {
+  display: flex;
+  height: 100%;
+  min-height: 300px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  color: var(--muted);
+  text-align: center;
+}
+
+.results-empty-icon {
+  display: flex;
+  width: 92px;
+  height: 74px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-strong);
+  border-radius: 9px;
+  color: #a4a9b0;
+}
+
+.results-empty-icon svg {
+  width: 35px;
+  height: 35px;
+  stroke-width: 1.25;
+}
+
+.results-empty h2 {
+  margin: 21px 0 8px;
+  color: var(--ink);
+  font-size: 20px;
+  font-weight: 650;
+}
+
+.results-empty p {
+  margin: 0;
+  font-size: 13px;
+}
+
+.artifact-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 18px;
+}
+
+.artifact-card {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: #fff;
+}
+
+.artifact-card > header {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 10px 12px 10px 15px;
+  border-bottom: 1px solid var(--border);
+}
+
+.artifact-card h2 {
+  margin: 0;
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 620;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.artifact-card header p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 9px;
+}
+
+.artifact-card header a {
+  display: flex;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  color: #565c64;
+}
+
+.artifact-card header a:hover {
+  background: var(--soft);
+}
+
+.artifact-card header svg {
+  width: 16px;
+  height: 16px;
+}
+
+.artifact-card > img {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 560px;
+  object-fit: contain;
+  background: #fff;
+}
+
+.artifact-loading,
+.artifact-error {
+  margin: 0;
+  padding: 24px 15px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.artifact-truncated {
+  margin: 0;
+  border-bottom: 1px solid var(--border);
+  background: #f8f8f8;
+  padding: 9px 15px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.artifact-error {
+  color: var(--danger);
+}
+
+.artifact-text {
+  max-height: 480px;
+  margin: 0;
+  overflow: auto;
+  background: #fbfbfb;
+  padding: 16px;
+  color: #30343a;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.table-scroll {
+  max-height: 480px;
+  overflow: auto;
+}
+
+.table-scroll table {
+  width: 100%;
+  border-collapse: collapse;
+  color: #30343a;
+  font-size: 11px;
+  text-align: left;
+}
+
+.table-scroll th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #f2f3f4;
+  font-weight: 620;
+}
+
+.table-scroll th,
+.table-scroll td {
+  max-width: 260px;
+  padding: 8px 10px;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.download-row {
+  display: flex;
+  min-height: 72px;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  color: var(--ink);
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.download-row:hover {
+  background: #fafafa;
+}
+
+.download-row svg {
+  width: 19px;
+  height: 19px;
+  color: #69707a;
+}
+
+.download-row span {
+  flex: 1;
+}
+
+.notice {
+  position: fixed;
+  right: 22px;
+  bottom: 22px;
+  z-index: 50;
+  display: flex;
+  max-width: min(430px, calc(100vw - 44px));
+  align-items: flex-start;
+  gap: 14px;
+  border: 1px solid #d7a4a4;
+  border-radius: 8px;
+  background: #fffafa;
+  box-shadow: 0 10px 30px rgba(20, 20, 20, 0.12);
+  padding: 12px 13px;
+  color: #762323;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.notice span {
+  flex: 1;
+}
+
+.notice button {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.empty-workspace-content {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  color: var(--muted);
+  text-align: center;
+}
+
+.empty-workspace-content button {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  gap: 8px;
+  margin-top: 20px;
+  border: 1px solid var(--ink);
+  border-radius: 7px;
+  background: var(--ink);
+  padding: 0 17px;
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.empty-workspace-content button svg {
+  width: 17px;
+  height: 17px;
+}
+
+.loading-screen {
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  background: #fff;
+}
+
+.loading-line {
+  width: 130px;
+  height: 2px;
+  margin: 28px 0 15px;
+  overflow: hidden;
+  background: #e4e6e8;
+}
+
+.loading-line::after {
+  display: block;
+  width: 48%;
+  height: 100%;
+  background: var(--ink);
+  animation: loading 1.3s ease-in-out infinite;
+  content: "";
+}
+
+.loading-screen p {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.login-shell {
+  display: flex;
+  width: 100vw;
+  min-height: 100vh;
+  min-height: 100dvh;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  padding: 24px;
+}
+
+.login-card {
+  width: min(100%, 390px);
+}
+
+.login-card .brand {
+  margin-bottom: 70px;
+}
+
+.login-icon {
+  display: flex;
+  width: 44px;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+}
+
+.login-icon svg {
+  width: 19px;
+  height: 19px;
+  stroke-width: 1.6;
+}
+
+.login-card h1 {
+  margin: 22px 0 9px;
+  font-size: 25px;
+  font-weight: 650;
+  letter-spacing: -0.025em;
+}
+
+.login-card > p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.login-card form {
+  margin-top: 28px;
+}
+
+.login-card label {
+  display: block;
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 620;
+}
+
+.login-input-row {
+  display: grid;
+  grid-template-columns: 1fr 46px;
+  height: 48px;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+}
+
+.login-input-row:focus-within {
+  border-color: #757b83;
+  box-shadow: 0 0 0 1px #757b83;
+}
+
+.login-input-row input {
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  padding: 0 13px;
+}
+
+.login-input-row button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: var(--ink);
+  color: #fff;
+  cursor: pointer;
+}
+
+.login-input-row button:disabled {
+  background: #e5e7e9;
+  color: #9ba0a7;
+}
+
+.login-input-row svg {
+  width: 18px;
+  height: 18px;
+}
+
+.form-error {
+  margin: 9px 0 0;
+  color: var(--danger);
+  font-size: 12px;
+}
+
+.login-card .login-footnote {
+  margin-top: 17px;
+  font-size: 11px;
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes loading {
+  from { transform: translateX(-105%); }
+  to { transform: translateX(215%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
+
+@media (max-width: 1050px) {
+  .sidebar {
+    width: 240px;
+    min-width: 240px;
+  }
+
+  .conversation-pane {
+    min-width: 430px;
+  }
+
+  .results-wrap {
+    min-width: 330px;
+    max-width: none;
+  }
+}
+
+@media (max-width: 800px) {
+  body {
+    overflow-y: auto;
+  }
+
+  .app-shell {
+    min-height: 100dvh;
+    height: auto;
+    overflow: visible;
+  }
+
+  .icon-button.mobile-only {
+    display: inline-flex;
+  }
+
+  .sidebar {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: min(310px, calc(100vw - 46px));
+    min-width: 0;
+    transform: translateX(-105%);
+    box-shadow: 10px 0 28px rgba(20, 20, 20, 0.12);
+    transition: transform 180ms ease;
+  }
+
+  .sidebar--open {
+    transform: translateX(0);
+  }
+
+  .sidebar-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 19;
+    display: block;
+    border: 0;
+    background: rgba(15, 17, 19, 0.22);
+  }
+
+  .workspace {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .conversation-pane {
+    min-width: 0;
+    min-height: 70vh;
+    min-height: 70dvh;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .conversation-header,
+  .results-header {
+    height: 65px;
+    min-height: 65px;
+  }
+
+  .conversation-header {
+    justify-content: flex-start;
+    gap: 10px;
+    padding: 0 13px;
+  }
+
+  .conversation-header > .icon-button:last-child {
+    margin-left: auto;
+  }
+
+  .conversation-title {
+    flex: 1;
+  }
+
+  .conversation-title h1,
+  .results-header h1 {
+    font-size: 18px;
+  }
+
+  .thread-viewport {
+    min-height: calc(70dvh - 65px);
+    padding: 24px 14px 0;
+  }
+
+  .message-stack {
+    gap: 20px;
+  }
+
+  .message-bubble {
+    max-width: 88%;
+    font-size: 14px;
+  }
+
+  .assistant-mark {
+    width: 32px;
+    height: 32px;
+  }
+
+  .plan-card {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .plan-card li {
+    grid-template-columns: 20px minmax(0, 1fr);
+  }
+
+  .step-state {
+    grid-column: 2;
+  }
+
+  .composer-footer {
+    padding-bottom: 14px;
+  }
+
+  .workbench-divider {
+    display: none;
+  }
+
+  .results-wrap {
+    width: 100% !important;
+    min-width: 0;
+    height: auto;
+  }
+
+  .results-pane {
+    min-height: 55vh;
+    min-height: 55dvh;
+  }
+
+  .results-header {
+    padding: 0 18px;
+  }
+
+  .result-tabs {
+    gap: 22px;
+    padding: 0 15px;
+  }
+
+  .results-content {
+    min-height: 380px;
+    padding: 16px;
+  }
+
+  .results-empty {
+    min-height: 330px;
+  }
+
+  .notice {
+    right: 12px;
+    bottom: 12px;
+    max-width: calc(100vw - 24px);
+  }
+}
+
+@media (max-width: 420px) {
+  .brand {
+    font-size: 25px;
+  }
+
+  .conversation-status {
+    display: none;
+  }
+
+  .conversation-title h1 {
+    font-size: 16px;
+  }
+
+  .message--assistant {
+    gap: 10px;
+  }
+
+  .message-bubble {
+    padding: 12px 13px;
+  }
+
+  .composer {
+    min-height: 105px;
+  }
+
+  .composer-input {
+    min-height: 58px;
+  }
+
+  .plan-card > header {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .result-tabs button {
+    font-size: 13px;
+  }
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,65 @@
+export type SessionStatus =
+  | "idle"
+  | "thinking"
+  | "awaiting_approval"
+  | "running"
+  | "failed";
+
+export type Message = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  created_at: string;
+};
+
+export type Upload = {
+  id: string;
+  name: string;
+  kind: string;
+  size: number;
+};
+
+export type PlanStep = {
+  id: string;
+  tool_id: string;
+  label: string;
+  status: "pending" | "running" | "succeeded" | "failed" | "skipped";
+  reason: string | null;
+};
+
+export type Plan = {
+  id: string;
+  digest: string;
+  status: "proposed" | "approved" | "completed" | "failed";
+  summary: string;
+  steps: PlanStep[];
+};
+
+export type ArtifactKind = "figure" | "table" | "evidence" | "download";
+
+export type Artifact = {
+  id: string;
+  name: string;
+  kind: ArtifactKind;
+  media_type: string;
+  url: string;
+  tool_id: string;
+};
+
+export type Session = {
+  id: string;
+  title: string;
+  updated_at: string;
+  status: SessionStatus;
+  messages: Message[];
+  uploads: Upload[];
+  plan: Plan | null;
+  artifacts: Artifact[];
+  error: string | null;
+};
+
+export type SessionSummary = Pick<Session, "id" | "title" | "updated_at">;
+
+export type SessionsResponse = {
+  sessions: SessionSummary[];
+};

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/web/tests/api.test.ts
+++ b/web/tests/api.test.ts
@@ -1,0 +1,72 @@
+import { ApiError, api } from "../src/api";
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+describe("API client", () => {
+  it("keeps authentication in a same-origin cookie and sends the login token only in the request body", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ authenticated: true }),
+    );
+
+    await api.login("preview-secret");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/login",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "same-origin",
+        body: JSON.stringify({ token: "preview-secret" }),
+      }),
+    );
+  });
+
+  it("binds approval to the exact plan id and digest", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ id: "session-1" }),
+    );
+
+    await api.approvePlan("session-1", "plan-7", "sha256:digest");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/sessions/session-1/approve",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ plan_id: "plan-7", plan_digest: "sha256:digest" }),
+      }),
+    );
+  });
+
+  it("uses multipart FormData for uploads without overriding its content type", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ id: "session-1" }),
+    );
+    const file = new File(["content"], "sample.h5ad", { type: "application/x-hdf5" });
+
+    await api.upload("session-1", file);
+
+    const request = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(request.body).toBeInstanceOf(FormData);
+    expect((request.headers as Headers).has("Content-Type")).toBe(false);
+  });
+
+  it("shows a stable server detail and hides unknown non-JSON failures", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ detail: "invalid_upload_type" }, { status: 400 }))
+      .mockResolvedValueOnce(new Response("<private traceback>", { status: 500 }));
+
+    await expect(api.createSession()).rejects.toEqual(
+      expect.objectContaining<Partial<ApiError>>({ status: 400, message: "invalid_upload_type" }),
+    );
+    await expect(api.createSession()).rejects.toEqual(
+      expect.objectContaining<Partial<ApiError>>({
+        status: 500,
+        message: "The request could not be completed. Please try again.",
+      }),
+    );
+  });
+});

--- a/web/tests/app-polling.test.tsx
+++ b/web/tests/app-polling.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from "@testing-library/react";
+import App from "../src/App";
+import type { Session } from "../src/types";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const makeSession = (status: Session["status"]): Session => ({
+  id: "session-1",
+  title: "Polling assessment",
+  updated_at: "2026-09-05T06:00:00Z",
+  status,
+  messages: [],
+  uploads: [],
+  plan: null,
+  artifacts: [],
+  error: null,
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("session loading and polling", () => {
+  it("keeps retrying a busy session after a transient poll failure", async () => {
+    let sessionReads = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const path = String(input);
+      if (path === "/api/sessions") {
+        return jsonResponse({
+          sessions: [{ id: "session-1", title: "Polling assessment", updated_at: "2026-09-05T06:00:00Z" }],
+        });
+      }
+      if (path === "/api/sessions/session-1") {
+        sessionReads += 1;
+        if (sessionReads === 1) return jsonResponse(makeSession("thinking"));
+        if (sessionReads === 2) return jsonResponse({ detail: "temporary_unavailable" }, 503);
+        if (sessionReads === 3) return jsonResponse(makeSession("thinking"));
+        return jsonResponse(makeSession("idle"));
+      }
+      throw new Error(`Unexpected request: ${path}`);
+    });
+
+    render(<App />);
+
+    expect(await screen.findAllByText("thinking")).toHaveLength(2);
+    expect(await screen.findByRole("alert", {}, { timeout: 2_000 })).toHaveTextContent(
+      "temporary_unavailable",
+    );
+    expect(await screen.findAllByText("idle", {}, { timeout: 6_000 })).toHaveLength(2);
+    expect(sessionReads).toBe(4);
+  }, 8_000);
+
+  it("continues normal polling when a successful response remains busy", async () => {
+    let sessionReads = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const path = String(input);
+      if (path === "/api/sessions") {
+        return jsonResponse({
+          sessions: [{ id: "session-1", title: "Polling assessment", updated_at: "2026-09-05T06:00:00Z" }],
+        });
+      }
+      sessionReads += 1;
+      if (sessionReads < 3) return jsonResponse(makeSession("running"));
+      return jsonResponse(makeSession("idle"));
+    });
+
+    render(<App />);
+
+    expect(await screen.findAllByText("running")).toHaveLength(2);
+    expect(await screen.findAllByText("idle", {}, { timeout: 3_500 })).toHaveLength(2);
+    expect(sessionReads).toBe(3);
+  }, 5_000);
+
+  it("aborts an in-flight poll when the app unmounts", async () => {
+    let sessionReads = 0;
+    let pollSignal: AbortSignal | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const path = String(input);
+      if (path === "/api/sessions") {
+        return jsonResponse({
+          sessions: [{ id: "session-1", title: "Polling assessment", updated_at: "2026-09-05T06:00:00Z" }],
+        });
+      }
+      sessionReads += 1;
+      if (sessionReads === 1) return jsonResponse(makeSession("running"));
+      pollSignal = init?.signal ?? undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        pollSignal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+      });
+    });
+
+    const view = render(<App />);
+    expect(await screen.findAllByText("running")).toHaveLength(2);
+    await vi.waitFor(() => expect(pollSignal).toBeDefined(), { timeout: 2_000 });
+
+    view.unmount();
+
+    expect(pollSignal?.aborted).toBe(true);
+  });
+
+  it("stops polling and returns to login after a 401", async () => {
+    let sessionReads = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const path = String(input);
+      if (path === "/api/sessions") {
+        return jsonResponse({
+          sessions: [{ id: "session-1", title: "Polling assessment", updated_at: "2026-09-05T06:00:00Z" }],
+        });
+      }
+      sessionReads += 1;
+      if (sessionReads === 1) return jsonResponse(makeSession("thinking"));
+      return jsonResponse({ detail: "authentication_required" }, 401);
+    });
+
+    render(<App />);
+    expect(await screen.findAllByText("thinking")).toHaveLength(2);
+    expect(
+      await screen.findByRole("heading", { name: "Private research preview" }, { timeout: 2_000 }),
+    ).toBeInTheDocument();
+    const readsAfterLogout = sessionReads;
+    await new Promise((resolve) => window.setTimeout(resolve, 1_500));
+    expect(sessionReads).toBe(readsAfterLogout);
+  }, 5_000);
+
+  it("keeps the signed-in workspace visible when the selected session cannot load", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const path = String(input);
+      if (path === "/api/sessions") {
+        return jsonResponse({
+          sessions: [{ id: "session-1", title: "Unavailable assessment", updated_at: "2026-09-05T06:00:00Z" }],
+        });
+      }
+      return jsonResponse({ detail: "session_temporarily_unavailable" }, 503);
+    });
+
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "No analysis selected" })).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("session_temporarily_unavailable");
+    expect(screen.queryByRole("heading", { name: "Private research preview" })).not.toBeInTheDocument();
+  });
+});

--- a/web/tests/markdown-security.test.tsx
+++ b/web/tests/markdown-security.test.tsx
@@ -1,0 +1,52 @@
+import { MessagePrimitive, ThreadPrimitive } from "@assistant-ui/react";
+import { render, screen } from "@testing-library/react";
+import { MarkdownText } from "../src/components/MarkdownText";
+import { BridgeRuntimeProvider } from "../src/runtime/BridgeRuntimeProvider";
+import type { Session } from "../src/types";
+
+describe("Markdown rendering", () => {
+  it("does not load model-authored external images", async () => {
+    const session: Session = {
+      id: "session-1",
+      title: "Safe Markdown",
+      updated_at: "2026-09-05T06:00:00Z",
+      status: "idle",
+      messages: [
+        {
+          id: "message-1",
+          role: "assistant",
+          content: "Visible evidence note.\n\n![tracking pixel](https://tracker.example/pixel.png)",
+          created_at: "2026-09-05T06:00:00Z",
+        },
+      ],
+      uploads: [],
+      plan: null,
+      artifacts: [],
+      error: null,
+    };
+
+    render(
+      <BridgeRuntimeProvider
+        session={session}
+        disabled={false}
+        onSession={vi.fn()}
+        onError={vi.fn()}
+      >
+        <ThreadPrimitive.Root>
+          <ThreadPrimitive.Viewport>
+            <ThreadPrimitive.Messages>
+              {() => (
+                <MessagePrimitive.Root>
+                  <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
+                </MessagePrimitive.Root>
+              )}
+            </ThreadPrimitive.Messages>
+          </ThreadPrimitive.Viewport>
+        </ThreadPrimitive.Root>
+      </BridgeRuntimeProvider>,
+    );
+
+    expect(await screen.findByText("Visible evidence note.")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+});

--- a/web/tests/plan-card.test.tsx
+++ b/web/tests/plan-card.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PlanCard } from "../src/components/PlanCard";
+import type { Plan } from "../src/types";
+
+const plan: Plan = {
+  id: "plan-1",
+  digest: "sha256:exact",
+  status: "proposed",
+  summary: "Review the declared input before execution.",
+  steps: [
+    {
+      id: "step-1",
+      tool_id: "p0-01",
+      label: "Check input data",
+      status: "pending",
+      reason: null,
+    },
+  ],
+};
+
+describe("PlanCard", () => {
+  it("allows confirmation only for the proposed plan in awaiting-approval state", async () => {
+    const approve = vi.fn();
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <PlanCard plan={plan} sessionStatus="awaiting_approval" busy={false} onApprove={approve} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Confirm analysis" }));
+    expect(approve).toHaveBeenCalledOnce();
+
+    rerender(<PlanCard plan={plan} sessionStatus="running" busy={false} onApprove={approve} />);
+    expect(screen.getByRole("button", { name: "Analysis running…" })).toBeDisabled();
+  });
+});

--- a/web/tests/results-pane.test.tsx
+++ b/web/tests/results-pane.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { readBoundedText, ResultsPane, WorkbenchDivider } from "../src/components/ResultsPane";
+import type { Session } from "../src/types";
+
+const session: Session = {
+  id: "session id",
+  title: "Assessment",
+  updated_at: "2026-09-05T05:00:00Z",
+  status: "idle",
+  messages: [],
+  uploads: [],
+  plan: null,
+  error: null,
+  artifacts: [
+    {
+      id: "figure png",
+      name: "Observed figure.png",
+      kind: "figure",
+      media_type: "image/png",
+      url: "https://untrusted.example/private-path",
+      tool_id: "p0-01",
+    },
+    {
+      id: "figure svg",
+      name: "Observed figure.svg",
+      kind: "figure",
+      media_type: "image/svg+xml",
+      url: "/ignored",
+      tool_id: "p0-01",
+    },
+    {
+      id: "table id",
+      name: "Observed table",
+      kind: "table",
+      media_type: "text/tab-separated-values",
+      url: "/ignored",
+      tool_id: "p0-01",
+    },
+    {
+      id: "download id",
+      name: "Evidence bundle",
+      kind: "download",
+      media_type: "application/zip",
+      url: "/ignored",
+      tool_id: "p0-01",
+    },
+  ],
+};
+
+describe("ResultsPane", () => {
+  it("uses registered same-origin artifact routes instead of arbitrary response URLs", () => {
+    render(<ResultsPane session={session} />);
+    const image = screen.getByRole("img", { name: "Observed figure.svg" });
+    expect(image).toHaveAttribute(
+      "src",
+      "/api/sessions/session%20id/artifacts/figure%20svg",
+    );
+    expect(screen.getByRole("tab", { name: /^Figures/ })).toBeInTheDocument();
+    expect(image).not.toHaveAttribute("src", expect.stringContaining("untrusted.example"));
+  });
+
+  it("switches tabs and renders an authenticated table preview as inert cells", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("marker\tstate\nA\tobserved", {
+        status: 200,
+        headers: { "Content-Type": "text/tab-separated-values" },
+      }),
+    );
+    render(<ResultsPane session={session} />);
+
+    await user.click(screen.getByRole("tab", { name: /Tables/ }));
+
+    expect(await screen.findByRole("columnheader", { name: "marker" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "observed" })).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/sessions/session%20id/artifacts/table%20id",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+  });
+
+  it("lists all artifacts in Downloads while previewing one distinct figure view", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<ResultsPane session={session} />);
+    await user.click(screen.getByRole("tab", { name: /^Downloads/ }));
+
+    const originalLinks = Array.from(container.querySelectorAll<HTMLAnchorElement>(".download-row"));
+    expect(originalLinks.map((link) => link.getAttribute("href"))).toEqual([
+      "/api/sessions/session%20id/artifacts/figure%20png",
+      "/api/sessions/session%20id/artifacts/figure%20svg",
+      "/api/sessions/session%20id/artifacts/table%20id",
+      "/api/sessions/session%20id/artifacts/download%20id",
+    ]);
+  });
+
+  it("applies the same viewport-aware upper bound to keyboard resizing", () => {
+    const onWidth = vi.fn();
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1_000 });
+    render(<WorkbenchDivider width={435} onWidth={onWidth} />);
+
+    fireEvent.keyDown(screen.getByRole("separator"), { key: "ArrowLeft" });
+
+    expect(onWidth).toHaveBeenCalledWith(440);
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: originalWidth });
+  });
+
+  it("stops reading and cancels an artifact stream at the preview byte limit", async () => {
+    const cancel = vi.fn();
+    let pulls = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new TextEncoder().encode("x".repeat(160_000)));
+      },
+      cancel,
+    });
+
+    const result = await readBoundedText(new Response(stream), 200_000);
+
+    expect(result.truncated).toBe(true);
+    expect(result.text).toHaveLength(200_000);
+    expect(pulls).toBe(2);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/web/tests/setup.ts
+++ b/web/tests/setup.ts
@@ -1,0 +1,41 @@
+import "@testing-library/jest-dom/vitest";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  }),
+});
+
+Object.defineProperty(Element.prototype, "scrollIntoView", {
+  writable: true,
+  value: () => undefined,
+});
+
+Object.defineProperty(Element.prototype, "scrollTo", {
+  writable: true,
+  value: () => undefined,
+});
+
+Object.defineProperty(Element.prototype, "setPointerCapture", {
+  writable: true,
+  value: () => undefined,
+});
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+Object.defineProperty(globalThis, "ResizeObserver", {
+  writable: true,
+  value: ResizeObserverMock,
+});

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "tests"]
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,19 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+    port: 5173,
+    proxy: {
+      "/api": "http://127.0.0.1:8765",
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./tests/setup.ts",
+    restoreMocks: true,
+  },
+});


### PR DESCRIPTION
## Purpose
Let a researcher upload an H5AD, declare assay/count semantics, approve an input-QC plan, and inspect actual evidence in conversation.

## Delivered
- Private single-operator React/assistant-ui workbench and small FastAPI service.
- Existing PlanBuilder, exact approval digest, P0-01 execution and SQLite workflow events.
- Real figures, bounded table/evidence previews, registered downloads, transcript and refresh persistence.
- Startup-only exact ancestor trust with identity pins; strict defaults and private-leaf checks remain.
- Setup/interface documentation and a public validation record.

## Evidence
- Final server focused service/storage checks: 104 passed.
- Frontend: 16 passed; production build passed.
- Installed-wheel real browser conversation/upload/approval/QC/artifacts/follow-up/refresh/narrow-viewport scenario passed without API mocks.
- Registered download integrity checked against private receipts.
- Full server regression passed on the integration predecessor; changed paths were retested after review fixes. Required CI runs the exact PR revision.
- Independent storage, backend and frontend reviews, followed by final integration review: no remaining Critical/Important findings.

## Limits
This Web preview executes P0-01 input QC only. The 12 CLI/SDK packages are unchanged; full-chain Agent scientific input construction remains follow-up work. The model receives chat and execution status, not biological measurements. Model prose is not a P0-10-verified report. Missing design is not inferred. Candidate/shadow methods, domain_score=null and scientific release status remain unchanged.

No private resources, screenshots, transcripts, deployment identifiers, credentials or biological measurements are included. Deployment and real-data evidence stay private.

## Merge
Squash only after repository-gates succeeds for this head. The published tree matches the reviewed server tree. Completed implementation plan is closed; durable facts are in docs/web-preview.md and docs/validation/web_preview_20260905.md.
