### PR TITLE
Polish and simplify README homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,86 @@
-# BRIDGE
+<h1 align="center">BRIDGE</h1>
 
-*Brain-Referenced In vivo-to-in vitro Developmental Guidance and Evaluation*
+<p align="center">
+  <strong>A research agent for single-cell evidence in cell-therapy products.</strong>
+</p>
 
-BRIDGE helps researchers interpret single-cell transcriptomic evidence from
-cell-therapy products: which cell states are present, how they relate to the
-intended product, and what remains uncertain. The first use case is hPSC-derived
-midbrain dopaminergic products for Parkinson's disease research.
+<p align="center">
+  <a href="https://github.com/starvingarc/BRIDGE/actions/workflows/ci.yml"><img src="https://github.com/starvingarc/BRIDGE/actions/workflows/ci.yml/badge.svg?branch=main" alt="Repository CI status"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2E7B70" alt="MIT license"></a>
+  <a href="docs/product-principles.md"><img src="https://img.shields.io/badge/use-research_only-7867A6" alt="Research use only"></a>
+</p>
 
-## From a sample to traceable evidence
+<p align="center">
+  <a href="#get-started"><strong>Get started</strong></a> &nbsp;·&nbsp;
+  <a href="examples/README.md#synthetic-scrna-upload-demo">Try the sample data</a> &nbsp;·&nbsp;
+  <a href="docs/README.md">Documentation</a> &nbsp;·&nbsp;
+  <a href="docs/validation/README.md">Validation</a>
+</p>
 
-Upload a single-cell dataset and, optionally, a differentiation protocol.
-Review the extracted experimental facts, confirm the intended product, and
-approve a bounded analysis. Inspect quality checks, cell-state observations,
-method disagreements and the sources behind each result.
+---
 
-Target identity, regional identity and developmental stage are distinct
-questions. Results retain their values, denominators, source versions and
-limitations. Missing evidence is not a zero measurement, and agreement among
-methods using the same data is not independent validation.
+BRIDGE helps researchers explore cell states in cell-therapy products using
+single-cell data. The first use case is **hPSC-derived midbrain dopaminergic
+products for Parkinson's disease research**.
+
+<p align="center">
+  <a href="docs/assets/bridge-biological-workflow.svg"><img src="docs/assets/bridge-biological-workflow.svg" width="100%" alt="Conceptual evidence map: developmental references and a cell product inform identity, regional fidelity, development, composition, and proliferation and stress response, with traceable evidence outputs."></a>
+</p>
+
+<p align="center">
+  <em>Conceptual overview of the research workflow.</em>
+</p>
 
 ## Get started
 
-BRIDGE runs as a private Web application; no public hosted service is provided.
-See the [setup and usage guide](docs/web-preview.md) to start an instance.
+Run BRIDGE as a **private, self-hosted Web application for one operator**.
+Requires **Python 3.12** and **Node.js 22.12+**.
 
-For direct tool use, see the [question-led guide](docs/tool-packages.md) and
-[runnable examples](examples/README.md). The [validation records](docs/validation/README.md)
-describe the tested scope and remaining limitations.
+### 1. Install and build
 
-## Research use
+```bash
+git clone https://github.com/starvingarc/BRIDGE.git
+cd BRIDGE
 
-BRIDGE does not establish clinical safety or efficacy, validated potency,
-GMP release, or an absolute product ranking. Algorithm outputs and proposed
-explanations are not automatically qualified biological conclusions.
+python -m pip install ".[qc,web,evidence,process]"
+npm --prefix frontend ci
+npm --prefix frontend run build
+```
 
-[Documentation](docs/README.md) · [Contributing](CONTRIBUTING.md) · [MIT License](LICENSE)
+### 2. Configure your private instance
+
+Follow the [setup guide](docs/web-preview.md#start-a-private-instance) to
+configure private storage, operator authentication, a model provider and the
+built frontend. Store credentials in private runtime configuration outside the
+repository.
+
+Start the service, then open the address you configured:
+
+```bash
+python -m bridge.web
+```
+
+### 3. Try the sample data
+
+Explore the input format with the
+[synthetic scRNA sample](examples/README.md#synthetic-scrna-upload-demo),
+a small dataset for trying the upload interface and testing integrations.
+
+For direct Python or CLI use, see the [tool guide](docs/tool-packages.md) and
+[request examples](examples/README.md). Set the example paths and checksums
+for your own files before running.
+
+## Explore & contribute
+
+[Documentation](docs/README.md) ·
+[Scientific principles](docs/product-principles.md) ·
+[Privacy & provenance](docs/privacy-and-provenance.md) ·
+[Contributing](CONTRIBUTING.md) ·
+[Issues](https://github.com/starvingarc/BRIDGE/issues)
+
+---
+
+<p align="center">
+  <sub>Brain-Referenced In vivo-to-in vitro Developmental Guidance and Evaluation</sub><br>
+  <sub>Open source under the <a href="LICENSE">MIT License</a>.</sub>
+</p>


### PR DESCRIPTION
## Biological question

Make the project homepage easier to read for researchers exploring single-cell evidence in cell-therapy products.

## Data and controls

Documentation-only change. Reuses the existing conceptual workflow SVG. Research data, references and locked/sealed boundaries are unchanged.

## Biological findings

not_applicable — presentation and onboarding copy only.

## Meaning for product evaluation

A concise project introduction, workflow illustration and three-step setup guide. Research-use labeling and links to scientific principles and validation remain available.

## Remaining uncertainty

Scientific qualification and real-input acceptance remain documented in the existing validation records and active plans. GitHub's final rendering and hosted CI are checked separately from the private README preview.

## Interface contract

- CLI and Python SDK entrypoint: not_applicable; unchanged.
- Inputs: not_applicable; unchanged.
- Structured outputs and artifact manifests: not_applicable; unchanged.
- Eligibility, refusal behavior and stable reason codes: not_applicable; unchanged.
- Minimal valid and refused examples: not_applicable; existing examples linked.
- Contract and compatibility versioning: not_applicable; unchanged.

## Engineering record

- Changed file: README.md only.
- Centered title, status badges, concise navigation and existing workflow illustration.
- Added installation/setup/sample-data entry points.
- Removed the biological-question, inspectable-evidence and research-boundaries sections from the homepage; simplified explanatory copy.
- Stable docs and plans: unchanged; existing authoritative pages remain linked.
- Verification: repository policy check passed; git diff --check passed; 22 link/image references and local anchors passed; requested removals verified; private rendered preview inspected.
- Application code, assets, dependencies and tests are unchanged. Per repository guidance, the full application suite was not repeated locally for this documentation-only diff. Required GitHub CI remains the merge gate.
- Privacy: no runtime records, credentials, private paths or screenshots added.
